### PR TITLE
Add Android fixture build to pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,17 @@
 steps:
 
+  - name: 'Build Android test fixture - UE 4.27'
+    agents:
+      queue: opensource-mac-unreal-4.27
+    env:
+      UE_VERSION: "4.27"
+    plugins:
+      artifacts#v1.2.0:
+        upload:
+          - features/fixtures/mobile/Binaries/Android/TestFixture-Android-Shipping-arm64.apk
+    command: make features/fixtures/mobile/Binaries/Android/TestFixture-Android-Shipping-arm64.apk
+    timeout_in_minutes: 40
+
   - name: 'Build iOS test fixture - UE 4.27'
     agents:
       queue: opensource-mac-unreal-4.27


### PR DESCRIPTION
## Goal

Add Android TestFixture build to the CI pipeline.

## Testing

Covered by CI.  The initial build failures were the result of the build server being misconfigured and this has now been rectified.