### PR TITLE
[PLAT-7203] Include Bugsnag plug-in in test fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: package
 clean:
 	find . -type d -name Binaries -or -name Intermediate | xargs rm -rf
 	git clean -dfx Plugins/Bugsnag/Source/ThirdParty/BugsnagCocoa
-	rm -rf Build deps
+	rm -rf Build deps features/fixtures/mobile/Plugins/Bugsnag
 
 # Convenience target that ensures editor modules are up to date and opens the example project in Unreal Editor.
 editor: Binaries/Mac/UE4Editor-BugsnagExample.dylib
@@ -53,6 +53,7 @@ features/fixtures/mobile/Binaries/IOS/TestFixture-IOS-Shipping.ipa: features/fix
 
 # UE4Editor-TestFixture.dylib is required for BuildCookRun to succeed
 features/fixtures/mobile/Binaries/Mac/UE4Editor-TestFixture.dylib: BugsnagCocoa
+	rsync --exclude 'Binaries' --exclude 'Intermediate' --delete --recursive --times Plugins/Bugsnag features/fixtures/mobile/Plugins
 	"$(UE_BUILD)" TestFixture Mac Development -TargetType=Editor "$(TESTPROJ)"
 
 test: Binaries/Mac/UE4Editor-BugsnagExample.dylib

--- a/features/fixtures/mobile/.gitignore
+++ b/features/fixtures/mobile/.gitignore
@@ -74,3 +74,6 @@ Plugins/*/Intermediate/*
 DerivedDataCache/*
 
 .DS_Store
+
+# Bugsnag specific
+Plugins/Bugsnag/*

--- a/features/fixtures/mobile/Config/DefaultEngine.ini
+++ b/features/fixtures/mobile/Config/DefaultEngine.ini
@@ -27,3 +27,8 @@ bSupportsLandscapeRightOrientation=False
 bSupportsPortraitOrientation=True
 bShipForBitcode=False
 
+[/Script/Bugsnag.BugsnagSettings]
+ApiKey=12312312312312312312312312312312
+NotifyEndpoint="http://bs-local.com:9339/notify"
+SessionsEndpoint="http://bs-local.com:9339/sessions"
+

--- a/features/fixtures/mobile/TestFixture.uproject
+++ b/features/fixtures/mobile/TestFixture.uproject
@@ -12,6 +12,10 @@
 	],
 	"Plugins": [
 		{
+			"Name": "Bugsnag",
+			"Enabled": true
+		},
+		{
 			"Name": "OculusVR",
 			"Enabled": false,
 			"SupportedTargetPlatforms": [


### PR DESCRIPTION
Includes the Bugsnag plug-in in the test fixture app.

Unreal Build Tool does not appear to support symbolic links (it complained that it could not find the Bugsnag plug-in) so this uses `rsync` to copy the plug-in into the fixture project's directory.

Verified that crashing the (iOS) test fixture (enter "crash$" into its UI) results in an event being sent to http://bs-local.com:9339/notify 🎉 