### PR TITLE
[PLAT-7155] Add IPlatformBugsnag (native notifier wrapper)

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
@@ -1,0 +1,113 @@
+#include "ApplePlatformBugsnag.h"
+
+#import <Bugsnag/Bugsnag.h>
+
+DEFINE_PLATFORM_BUGSNAG(FApplePlatformBugsnag);
+
+void FApplePlatformBugsnag::Start(const TSharedPtr<FBugsnagConfiguration>& Configuration)
+{
+}
+
+void FApplePlatformBugsnag::Notify(const FString& ErrorClass, const FString& Message)
+{
+}
+
+void FApplePlatformBugsnag::Notify(const FString& ErrorClass, const FString& Message, const FBugsnagOnErrorCallback& Callback)
+{
+}
+
+void FApplePlatformBugsnag::Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace)
+{
+}
+
+void FApplePlatformBugsnag::Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
+	const FBugsnagOnErrorCallback& Callback)
+{
+}
+
+const FString FApplePlatformBugsnag::GetContext()
+{
+	return TEXT("");
+}
+
+void FApplePlatformBugsnag::SetContext(const FString& Context)
+{
+}
+
+const TSharedPtr<FBugsnagUser> FApplePlatformBugsnag::GetUser()
+{
+	return nullptr;
+}
+
+void FApplePlatformBugsnag::SetUser(const FString& Id, const FString& Email, const FString& Name)
+{
+}
+
+void FApplePlatformBugsnag::AddMetadata(const FString& Section, const TSharedPtr<FJsonObject>& Metadata)
+{
+}
+
+void FApplePlatformBugsnag::AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value)
+{
+}
+
+TSharedPtr<FJsonObject> FApplePlatformBugsnag::GetMetadata(const FString& Section)
+{
+	return nullptr;
+}
+
+TSharedPtr<FJsonValue> FApplePlatformBugsnag::GetMetadata(const FString& Section, const FString& Key)
+{
+	return nullptr;
+}
+
+void FApplePlatformBugsnag::ClearMetadata(const FString& Section)
+{
+}
+
+void FApplePlatformBugsnag::ClearMetadata(const FString& Section, const FString& Key)
+{
+}
+
+void FApplePlatformBugsnag::LeaveBreadcrumb(const FString& Message, const TSharedPtr<FJsonObject>& Metadata, EBugsnagBreadcrumbType Type)
+{
+}
+
+TArray<TSharedPtr<const class IBugsnagBreadcrumb>> FApplePlatformBugsnag::GetBreadcrumbs()
+{
+	return {};
+}
+
+void FApplePlatformBugsnag::MarkLaunchCompleted()
+{
+}
+
+TSharedPtr<FBugsnagLastRunInfo> FApplePlatformBugsnag::GetLastRunInfo()
+{
+	return nullptr;
+}
+
+void FApplePlatformBugsnag::StartSession()
+{
+}
+
+void FApplePlatformBugsnag::PauseSession()
+{
+}
+
+bool FApplePlatformBugsnag::ResumeSession()
+{
+	return false;
+}
+
+void FApplePlatformBugsnag::AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback)
+{
+}
+
+void FApplePlatformBugsnag::AddOnError(const FBugsnagOnErrorCallback& Callback)
+{
+}
+
+void FApplePlatformBugsnag::AddOnSession(const FBugsnagOnSessionCallback& Callback)
+{
+}

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "Interfaces/PlatformBugsnag.h"
+
+class FApplePlatformBugsnag : public IPlatformBugsnag
+{
+public:
+	void Start(const TSharedPtr<FBugsnagConfiguration>& Configuration) override;
+
+	void Notify(const FString& ErrorClass, const FString& Message) override;
+
+	void Notify(const FString& ErrorClass, const FString& Message, const FBugsnagOnErrorCallback& Callback) override;
+
+	void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace) override;
+
+	void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
+		const FBugsnagOnErrorCallback& Callback) override;
+
+	const FString GetContext() override;
+
+	void SetContext(const FString& Context) override;
+
+	const TSharedPtr<FBugsnagUser> GetUser() override;
+
+	void SetUser(const FString& Id, const FString& Email, const FString& Name) override;
+
+	void AddMetadata(const FString& Section, const TSharedPtr<FJsonObject>& Metadata) override;
+
+	void AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value) override;
+
+	TSharedPtr<FJsonObject> GetMetadata(const FString& Section) override;
+
+	TSharedPtr<FJsonValue> GetMetadata(const FString& Section, const FString& Key) override;
+
+	void ClearMetadata(const FString& Section) override;
+
+	void ClearMetadata(const FString& Section, const FString& Key) override;
+
+	void LeaveBreadcrumb(const FString& Message, const TSharedPtr<FJsonObject>& Metadata, EBugsnagBreadcrumbType Type) override;
+
+	TArray<TSharedPtr<const class IBugsnagBreadcrumb>> GetBreadcrumbs() override;
+
+	void MarkLaunchCompleted() override;
+
+	TSharedPtr<FBugsnagLastRunInfo> GetLastRunInfo() override;
+
+	void StartSession() override;
+
+	void PauseSession() override;
+
+	bool ResumeSession() override;
+
+	void AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback) override;
+
+	void AddOnError(const FBugsnagOnErrorCallback& Callback) override;
+
+	void AddOnSession(const FBugsnagOnSessionCallback& Callback) override;
+};
+
+DECLARE_PLATFORM_BUGSNAG(FApplePlatformBugsnag)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
@@ -1,4 +1,5 @@
 #include "BugsnagFunctionLibrary.h"
+#include "PlatformBugsnag.h"
 
 void UBugsnagFunctionLibrary::Start(const FString& ApiKey)
 {
@@ -8,23 +9,40 @@ void UBugsnagFunctionLibrary::Start(const FString& ApiKey)
 
 void UBugsnagFunctionLibrary::Start(const TSharedPtr<FBugsnagConfiguration>& Configuration)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.Start(Configuration);
+#else
+	UE_LOG(LogBugsnag, Warning, TEXT("Bugsnag is not implemented on this platform"));
+#endif
 }
 
 void UBugsnagFunctionLibrary::Notify(const FString& ErrorClass, const FString& Message)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.Notify(ErrorClass, Message);
+#endif
 }
 
 void UBugsnagFunctionLibrary::Notify(const FString& ErrorClass, const FString& Message, const FBugsnagOnErrorCallback& Callback)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.Notify(ErrorClass, Message, Callback);
+#endif
 }
 
 void UBugsnagFunctionLibrary::Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.Notify(ErrorClass, Message, StackTrace);
+#endif
 }
 
 void UBugsnagFunctionLibrary::Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
 	const FBugsnagOnErrorCallback& Callback)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.Notify(ErrorClass, Message, StackTrace, Callback);
+#endif
 }
 
 TArray<uint64> UBugsnagFunctionLibrary::CaptureStackTrace()
@@ -42,91 +60,161 @@ TArray<uint64> UBugsnagFunctionLibrary::CaptureStackTrace()
 
 const FString UBugsnagFunctionLibrary::GetContext()
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	return GPlatformBugsnag.GetContext();
+#else
 	return TEXT("");
+#endif
 }
 
 void UBugsnagFunctionLibrary::SetContext(const FString& Context)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.SetContext(Context);
+#endif
 }
 
 const TSharedPtr<FBugsnagUser> UBugsnagFunctionLibrary::GetUser()
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	return GPlatformBugsnag.GetUser();
+#else
 	return nullptr;
+#endif
 }
 
 void UBugsnagFunctionLibrary::SetUser(const FString& Id, const FString& Email, const FString& Name)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.SetUser(Id, Email, Name);
+#endif
 }
 
 void UBugsnagFunctionLibrary::AddMetadata(const FString& Section, const TSharedPtr<FJsonObject>& Metadata)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.AddMetadata(Section, Metadata);
+#endif
 }
 
 void UBugsnagFunctionLibrary::AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.AddMetadata(Section, Key, Value);
+#endif
 }
 
 TSharedPtr<FJsonObject> UBugsnagFunctionLibrary::GetMetadata(const FString& Section)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	return GPlatformBugsnag.GetMetadata(Section);
+#else
 	return nullptr;
+#endif
 }
 
 TSharedPtr<FJsonValue> UBugsnagFunctionLibrary::GetMetadata(const FString& Section, const FString& Key)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	return GPlatformBugsnag.GetMetadata(Section, Key);
+#else
 	return nullptr;
+#endif
 }
 
 void UBugsnagFunctionLibrary::ClearMetadata(const FString& Section)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.ClearMetadata(Section);
+#endif
 }
 
 void UBugsnagFunctionLibrary::ClearMetadata(const FString& Section, const FString& Key)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.ClearMetadata(Section, Key);
+#endif
 }
 
 void UBugsnagFunctionLibrary::LeaveBreadcrumb(const FString& Message, EBugsnagBreadcrumbType Type)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.LeaveBreadcrumb(Message, nullptr, Type);
+#endif
 }
 
 void UBugsnagFunctionLibrary::LeaveBreadcrumb(const FString& Message, const TSharedPtr<FJsonObject>& Metadata, EBugsnagBreadcrumbType Type)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.LeaveBreadcrumb(Message, Metadata, Type);
+#endif
 }
 
-TArray<const TSharedPtr<const class IBugsnagBreadcrumb>> UBugsnagFunctionLibrary::GetBreadcrumbs()
+TArray<TSharedPtr<const class IBugsnagBreadcrumb>> UBugsnagFunctionLibrary::GetBreadcrumbs()
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	return GPlatformBugsnag.GetBreadcrumbs();
+#else
 	return {};
+#endif
 }
 
 void UBugsnagFunctionLibrary::MarkLaunchCompleted()
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.MarkLaunchCompleted();
+#endif
 }
 
 TSharedPtr<FBugsnagLastRunInfo> UBugsnagFunctionLibrary::GetLastRunInfo()
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	return GPlatformBugsnag.GetLastRunInfo();
+#else
 	return nullptr;
+#endif
 }
 
 void UBugsnagFunctionLibrary::StartSession()
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.StartSession();
+#endif
 }
 
 void UBugsnagFunctionLibrary::PauseSession()
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.PauseSession();
+#endif
 }
 
 bool UBugsnagFunctionLibrary::ResumeSession()
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	return GPlatformBugsnag.ResumeSession();
+#else
 	return false;
+#endif
 }
 
 void UBugsnagFunctionLibrary::AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.AddOnBreadcrumb(Callback);
+#endif
 }
 
 void UBugsnagFunctionLibrary::AddOnError(const FBugsnagOnErrorCallback& Callback)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.AddOnError(Callback);
+#endif
 }
 
 void UBugsnagFunctionLibrary::AddOnSession(const FBugsnagOnSessionCallback& Callback)
 {
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+	GPlatformBugsnag.AddOnSession(Callback);
+#endif
 }

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagModule.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagModule.cpp
@@ -1,23 +1,15 @@
 #include "BugsnagModule.h"
-#include "BugsnagConfiguration.h"
-#include "Modules/ModuleManager.h"
+#include "BugsnagFunctionLibrary.h"
 
-// TODO: Remove this PLATFORM_APPLE section
-#if PLATFORM_APPLE
-#import <Bugsnag/Bugsnag.h>
-#import <BugsnagPrivate/BSG_KSSystemInfo.h>
-#endif
+#include "Modules/ModuleManager.h"
 
 void FBugsnagModule::StartupModule()
 {
-// TODO: Remove this PLATFORM_APPLE section
-#if PLATFORM_APPLE
 	TSharedPtr<FBugsnagConfiguration> Configuration = FBugsnagConfiguration::Load();
 	if (Configuration.IsValid() && !Configuration->GetApiKey().IsEmpty())
 	{
-		[Bugsnag startWithApiKey:@(TCHAR_TO_UTF8(*Configuration->GetApiKey()))];
+		UBugsnagFunctionLibrary::Start(Configuration);
 	}
-#endif
 }
 
 void FBugsnagModule::ShutdownModule() {}

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/IOS/IOSPlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/IOS/IOSPlatformBugsnag.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "Apple/ApplePlatformBugsnag.h"

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Interfaces/PlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Interfaces/PlatformBugsnag.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Json.h"
+
+#include "BugsnagBreadcrumbType.h"
+#include "BugsnagConfiguration.h"
+#include "BugsnagLastRunInfo.h"
+#include "BugsnagUser.h"
+
+class IPlatformBugsnag
+{
+public:
+	virtual void Start(const TSharedPtr<FBugsnagConfiguration>& Configuration) = 0;
+
+	virtual void Notify(const FString& ErrorClass, const FString& Message) = 0;
+
+	virtual void Notify(const FString& ErrorClass, const FString& Message, const FBugsnagOnErrorCallback& Callback) = 0;
+
+	virtual void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace) = 0;
+
+	virtual void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
+		const FBugsnagOnErrorCallback& Callback) = 0;
+
+	virtual const FString GetContext() = 0;
+
+	virtual void SetContext(const FString& Context) = 0;
+
+	virtual const TSharedPtr<FBugsnagUser> GetUser() = 0;
+
+	virtual void SetUser(const FString& Id, const FString& Email, const FString& Name) = 0;
+
+	virtual void AddMetadata(const FString& Section, const TSharedPtr<FJsonObject>& Metadata) = 0;
+
+	virtual void AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value) = 0;
+
+	virtual TSharedPtr<FJsonObject> GetMetadata(const FString& Section) = 0;
+
+	virtual TSharedPtr<FJsonValue> GetMetadata(const FString& Section, const FString& Key) = 0;
+
+	virtual void ClearMetadata(const FString& Section) = 0;
+
+	virtual void ClearMetadata(const FString& Section, const FString& Key) = 0;
+
+	virtual void LeaveBreadcrumb(const FString& Message, const TSharedPtr<FJsonObject>& Metadata, EBugsnagBreadcrumbType Type) = 0;
+
+	virtual TArray<TSharedPtr<const class IBugsnagBreadcrumb>> GetBreadcrumbs() = 0;
+
+	virtual void MarkLaunchCompleted() = 0;
+
+	virtual TSharedPtr<FBugsnagLastRunInfo> GetLastRunInfo() = 0;
+
+	virtual void StartSession() = 0;
+
+	virtual void PauseSession() = 0;
+
+	virtual bool ResumeSession() = 0;
+
+	virtual void AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback) = 0;
+
+	virtual void AddOnError(const FBugsnagOnErrorCallback& Callback) = 0;
+
+	virtual void AddOnSession(const FBugsnagOnSessionCallback& Callback) = 0;
+};
+
+#define DECLARE_PLATFORM_BUGSNAG(CLASS) \
+	typedef CLASS FPlatformBugsnag;     \
+	extern FPlatformBugsnag GPlatformBugsnag;
+
+#define DEFINE_PLATFORM_BUGSNAG(CLASS) \
+	CLASS GPlatformBugsnag;

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Mac/MacPlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Mac/MacPlatformBugsnag.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "Apple/ApplePlatformBugsnag.h"

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/PlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/PlatformBugsnag.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#if PLATFORM_IOS || PLATFORM_MAC
+#define PLATFORM_IMPLEMENTS_BUGSNAG 1
+#else
+#define PLATFORM_IMPLEMENTS_BUGSNAG 0
+#endif
+
+#if PLATFORM_IMPLEMENTS_BUGSNAG
+#include COMPILED_PLATFORM_HEADER(PlatformBugsnag.h)
+#endif

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagBreadcrumbType.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagBreadcrumbType.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CoreUObject.h"
+
 UENUM()
 enum class EBugsnagBreadcrumbType : uint8
 {

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
@@ -78,7 +78,7 @@ public:
 	static void LeaveBreadcrumb(const FString& Message, const TSharedPtr<FJsonObject>& Metadata,
 		EBugsnagBreadcrumbType Type = EBugsnagBreadcrumbType::Manual);
 
-	static TArray<const TSharedPtr<const class IBugsnagBreadcrumb>> GetBreadcrumbs();
+	static TArray<TSharedPtr<const class IBugsnagBreadcrumb>> GetBreadcrumbs();
 
 	// Crashes On Launch
 


### PR DESCRIPTION
`IPlatformBugsnag` provides an abstract interface to wrap the functionality of native notifiers.

On supported platforms `PLATFORM_IMPLEMENTS_BUGSNAG` is defined to be `1` and a global `GPlatformBugsnag` instance is available for use by the function library.