### PR TITLE
build: support running `make test` with granularity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ UE_EDITOR=$(UE_HOME)/Engine/Binaries/Mac/UE4Editor.app/Contents/MacOS/UE4Editor
 
 UPROJECT=$(PWD)/BugsnagExample.uproject
 TESTPROJ=$(PWD)/features/fixtures/mobile/TestFixture.uproject
+TESTSCOPE?=Bugsnag
 
 .PHONY: BugsnagCocoa clean e2e_android e2e_android_local e2e_ios e2e_ios_local editor format package test
 
@@ -57,7 +58,7 @@ features/fixtures/mobile/Binaries/Mac/UE4Editor-TestFixture.dylib: BugsnagCocoa
 	"$(UE_BUILD)" TestFixture Mac Development -TargetType=Editor "$(TESTPROJ)"
 
 test: Binaries/Mac/UE4Editor-BugsnagExample.dylib
-	"$(UE_EDITOR)" "$(UPROJECT)" -ExecCmds="Automation RunTests Bugsnag; Quit" -NoSplash -NullRHI -ReportOutputPath="$(PWD)/Saved/Automation/Reports"
+	"$(UE_EDITOR)" "$(UPROJECT)" -ExecCmds="Automation RunTests $(TESTSCOPE); Quit" -NoSplash -NullRHI -ReportOutputPath="$(PWD)/Saved/Automation/Reports"
 
 # https://www.unrealengine.com/en-US/marketplace-guidelines#263b
 package: BugsnagCocoa


### PR DESCRIPTION
Adds TESTSCOPE as an optional variable which can specify a substring required to be present in the test name. Examples:

```sh
make test TESTSCOPE=Config # run all tests with 'Config' in the name
make test TESTSCOPE=FBugsnagConfigurationSpec.MaxBreadcrumbs # run 1 test
```

I have an editor integration which can set the scope based on the current file/line, so I thought it might be a nice quality of life imnprovement to the makefile.