### PR TITLE
[PLAT-7232] Add basic E2E test

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -2,6 +2,7 @@
     "version": "0.2",
     "language": "en",
     "words": [
+        "Appium",
         "BSGJSON",
         "ooms",
         "UCLASS",

--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,8 @@ DerivedDataCache/*
 .DS_Store
 
 # Bugsnag specific
+Gemfile.lock
 Plugins/Bugsnag/Source/ThirdParty/BugsnagCocoa/include
+appium_server.log
 bugsnag-cocoa
+maze_output/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ e2e_ios: features/fixtures/mobile/Binaries/IOS/TestFixture-IOS-Shipping.ipa
 	bundle exec maze-runner --app=$< --farm=bs --device=IOS_12
 
 e2e_ios_local: features/fixtures/mobile/Binaries/IOS/TestFixture-IOS-Shipping.ipa
+	ideviceinstaller --uninstall com.bugsnag.TestFixture
 	bundle exec maze-runner --app=$< --farm=local --os=ios --os-version=14 --apple-team-id=372ZUL2ZB7 --udid="$(shell idevice_id -l)"
 
 features/fixtures/mobile/Binaries/Android/TestFixture-Android-Shipping-arm64.apk: features/fixtures/mobile/Binaries/Mac/UE4Editor-TestFixture.dylib

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/LogBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/LogBugsnag.h
@@ -2,4 +2,4 @@
 
 #include "Logging/LogMacros.h"
 
-DECLARE_LOG_CATEGORY_EXTERN(LogBugsnag, All, All);
+BUGSNAG_API DECLARE_LOG_CATEGORY_EXTERN(LogBugsnag, All, All);

--- a/features/dummy.feature
+++ b/features/dummy.feature
@@ -1,5 +1,0 @@
-Feature: Dummy
-
-  Scenario: Crash
-    When I run "Crash"
-    Then the app is not running

--- a/features/fixtures/mobile/Config/DefaultEngine.ini
+++ b/features/fixtures/mobile/Config/DefaultEngine.ini
@@ -26,9 +26,5 @@ bSupportsLandscapeLeftOrientation=False
 bSupportsLandscapeRightOrientation=False
 bSupportsPortraitOrientation=True
 bShipForBitcode=False
-
-[/Script/Bugsnag.BugsnagSettings]
-ApiKey=12312312312312312312312312312312
-NotifyEndpoint="http://bs-local.com:9339/notify"
-SessionsEndpoint="http://bs-local.com:9339/sessions"
+bDisableHTTPS=True
 

--- a/features/fixtures/mobile/Source/TestFixture.Target.cs
+++ b/features/fixtures/mobile/Source/TestFixture.Target.cs
@@ -8,6 +8,9 @@ public class TestFixtureTarget : TargetRules
 
 		DefaultBuildSettings = BuildSettingsVersion.Latest;
 
+		bEnforceIWYU = true;
+		bUseUnityBuild = false;
+
 		ExtraModuleNames.AddRange( new string[] { "TestFixture" } );
 	}
 }

--- a/features/fixtures/mobile/Source/TestFixture/Module.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Module.cpp
@@ -1,10 +1,35 @@
 #include "CoreGlobals.h"
 #include "Modules/ModuleManager.h"
 
+#if PLATFORM_IOS
+
+#include <objc/runtime.h>
+
+static void (*UIAlertController_addAction_orig)(id self, SEL _cmd, UIAlertAction* action);
+
+static void UIAlertController_addAction_swizzled(id self, SEL _cmd, UIAlertAction* action)
+{
+	if ([action.title isEqual:@"Cancel"])
+	{
+		// Awful hack to stop Appium's send_keys action dismissing the text entry alert via the cancel button.
+		return;
+	}
+	UIAlertController_addAction_orig(self, _cmd, action);
+}
+
+#endif
+
 class FTestFixture : public IModuleInterface
 {
 public:
-	virtual void StartupModule() override{};
+	virtual void StartupModule() override
+	{
+#if PLATFORM_IOS
+		UIAlertController_addAction_orig = (void (*)(id, SEL, UIAlertAction*))method_setImplementation(
+			class_getInstanceMethod([UIAlertController class], NSSelectorFromString(@"addAction:")),
+			(IMP)UIAlertController_addAction_swizzled);
+#endif
+	};
 
 	virtual void ShutdownModule() override{};
 };

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
@@ -1,0 +1,13 @@
+#include "Scenario.h"
+
+class BadMemoryAccessScenario : public Scenario
+{
+public:
+	void Run() override
+	{
+		volatile int* Pointer = nullptr;
+		*Pointer = 42;
+	}
+};
+
+REGISTER_SCENARIO(BadMemoryAccessScenario);

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/Scenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/Scenario.cpp
@@ -1,0 +1,3 @@
+#include "Scenario.h"
+
+Scenario* Scenario::CurrentScenario = nullptr;

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/Scenario.h
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/Scenario.h
@@ -1,0 +1,98 @@
+#include "BugsnagFunctionLibrary.h"
+
+#include <map>
+#include <string>
+
+class Scenario
+{
+public:
+	static Scenario* CurrentScenario;
+
+	static void Start(const FString& ScenarioName)
+	{
+		UE_LOG(LogTemp, Display, TEXT("Starting scenario \"%s\""), *ScenarioName);
+
+		if (!Instantiate(TCHAR_TO_UTF8(*ScenarioName)))
+		{
+			UE_LOG(LogTemp, Error, TEXT("Could not instantiate scenario \"%s\""), *ScenarioName);
+			return;
+		}
+
+		UE_LOG(LogTemp, Display, TEXT("%s::Configure()"), *ScenarioName);
+		CurrentScenario->Configure();
+
+		UE_LOG(LogTemp, Display, TEXT("%s::StartBugsnag()"), *ScenarioName);
+		CurrentScenario->StartBugsnag();
+	}
+
+	static void Run(const FString& ScenarioName)
+	{
+		Start(ScenarioName);
+
+		if (CurrentScenario)
+		{
+			UE_LOG(LogTemp, Display, TEXT("%s::Run()"), *ScenarioName);
+
+			CurrentScenario->Run();
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+
+	Scenario()
+	{
+		Configuration = new FBugsnagConfiguration(
+			TEXT("12312312312312312312312312312312"));
+
+		Configuration->SetEndpoints(
+			TEXT("http://bs-local.com:9339/notify"),
+			TEXT("http://bs-local.com:9339/sessions"));
+	}
+
+	virtual void Configure()
+	{
+	}
+
+	virtual void StartBugsnag()
+	{
+		UBugsnagFunctionLibrary::Start(MakeShareable(Configuration));
+	}
+
+	virtual void Run() = 0;
+
+	FBugsnagConfiguration* Configuration;
+
+	////////////////////////////////////////////////////////////////////////////
+
+	typedef class Scenario* (*Factory)(void);
+
+	static int Register(const std::string& Name, Factory Factory)
+	{
+		GetFactories()[Name] = Factory;
+		return 1;
+	}
+
+	static bool Instantiate(const std::string& Name)
+	{
+		CurrentScenario = GetFactories()[Name]();
+		return CurrentScenario != nullptr;
+	}
+
+private:
+	static std::map<std::string, Factory>& GetFactories()
+	{
+		static std::map<std::string, Factory> Factories;
+		return Factories;
+	}
+};
+
+#define REGISTER_SCENARIO(CLASSNAME)                                      \
+	static Scenario* Instantiate___##CLASSNAME(void)                      \
+	{                                                                     \
+		return new CLASSNAME;                                             \
+	}                                                                     \
+	static int Register___##CLASSNAME()                                   \
+	{                                                                     \
+		return Scenario::Register(#CLASSNAME, Instantiate___##CLASSNAME); \
+	}                                                                     \
+	static int Registered___##CLASSNAME = Register___##CLASSNAME();

--- a/features/fixtures/mobile/Source/TestFixtureEditor.Target.cs
+++ b/features/fixtures/mobile/Source/TestFixtureEditor.Target.cs
@@ -8,6 +8,9 @@ public class TestFixtureEditorTarget : TargetRules
 
 		DefaultBuildSettings = BuildSettingsVersion.Latest;
 
+		bEnforceIWYU = true;
+		bUseUnityBuild = false;
+
 		ExtraModuleNames.AddRange( new string[] { "TestFixture" } );
 	}
 }

--- a/features/steps/unreal_steps.rb
+++ b/features/steps/unreal_steps.rb
@@ -1,23 +1,13 @@
-When('I run {string}') do |input|
-  # Unreal Engine doesn't support screen readers on Android, so the test fixture consists
-  # of a full-screen text field (on all platforms.)
-  Appium::TouchAction.new.tap({:x => 100, :y => 100}).perform
+When('I configure Bugsnag for {string}') do |scenario_name|
+  enter_text "Start #{scenario_name}"
+end
 
-  # Wait for keyboard to appear
-  sleep 1
+When('I relaunch the app') do
+  Maze.driver.launch_app
+end
 
-  # '$' allows our OnTextChanged function to detect the end of text input.
-  Maze.driver.driver.action.send_keys("#{input}$").perform
-
-  case Maze.driver.capabilities['platformName']
-  when 'iOS'
-    # On iOS, tapping an EditableText causes an alert with text field to be presented, and
-    # the EditableText is only updated when the OK button is tapped.
-    Maze.driver.click_element("OK")
-
-    # For some reason when running on a locally connected iOS device, the send_keys action
-    # can end up dismissing the alert via its Cancel button, making this unreliable :-(
-  end
+When('I run {string}') do |scenario_name|
+  enter_text "Run #{scenario_name}"
 end
 
 Then('the app is not running') do
@@ -26,10 +16,33 @@ Then('the app is not running') do
   end
 end
 
+def enter_text(text)
+  # Unreal Engine doesn't support screen readers on Android, so the test fixture
+  # consists of a full-screen text field (on all platforms.)
+  Appium::TouchAction.new.tap({:x => 100, :y => 100}).perform
+
+  # Wait for keyboard to appear
+  sleep 1
+
+  # '$' allows our OnTextChanged function to detect the end of text input.
+  Maze.driver.driver.action.send_keys("#{text}$").perform
+
+  if Maze.driver.capabilities['platformName'] == 'iOS'
+    # On iOS, tapping an EditableText causes an alert with text field to be
+    # presented, and the EditableText is only updated when the OK button is
+    # tapped. For an unknown reason, when running on a locally connected iOS
+    # device, the send_keys action dismisses the alert automatically (and
+    # unfortunately prefers the Cancel button.)
+    if Maze.config.farm == :bs
+      Maze.driver.click_element("OK")
+    end
+  end
+end
+
 def wait_for_true
   attempts = 0
   assertion_passed = false
-  until (attempts >= 5) || assertion_passed
+  until (attempts >= 10) || assertion_passed
     attempts += 1
     assertion_passed = yield
     sleep 1

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -1,0 +1,9 @@
+Feature: Unhandled errors
+
+  Scenario: BadMemoryAccessScenario
+    When I run "BadMemoryAccessScenario"
+    And the app is not running
+    And I relaunch the app
+    And I configure Bugsnag for "BadMemoryAccessScenario"
+    Then I wait to receive an error
+    And the event "unhandled" is true


### PR DESCRIPTION
Adds a simple test case, `BadMemoryAccessScenario`, to demonstrate triggering a crash and receiving an unhandled error event.

The test framework runs the test by inputting commands that include the scenario name to the fixture app's UI.

Currently this is limited to entering a single command per run of the app because we are not able to clear the text (we cannot access the text entity to clear it on Android) and the [OnTextChanged](https://github.com/bugsnag/bugsnag-unreal/blob/nickdowell/first-e2e-test/features/fixtures/mobile/Source/TestFixture/TestFixtureBlueprintFunctionLibrary.cpp#L44-L54) callback is not able to modify anything.

The fixture app implements a workaround for the text input bug (due to Appium canceling the alert) on iOS when running locally.

Test scenario classes are registered using the [REGISTER_SCENARIO](https://github.com/bugsnag/bugsnag-unreal/blob/nickdowell/first-e2e-test/features/fixtures/mobile/Source/TestFixture/Scenarios/Scenario.h#L89) macro to allow dynamic name-based instantiation.

Investigated implementing scenarios as UObjects but that turned out to be more complicated as it requires participating in Unreal Engine's object life-cycle - UObjects represent game entities and need to be "attached" to a parent or "outer" object.