### PR TITLE
Fix Cocoa configuration defaults

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
@@ -14,21 +14,13 @@
 #import <BugsnagPrivate/BugsnagConfiguration+Private.h>
 #import <BugsnagPrivate/BugsnagNotifier.h>
 
-static NSString* _Nullable NSStringFromFString(const FString& String, bool ReturnNilForEmpty = true)
+static NSString* _Nullable NSStringFromFString(const FString& String)
 {
-	if (ReturnNilForEmpty && String.IsEmpty())
-	{
-		return nil;
-	}
 	return @(TCHAR_TO_UTF8(*String));
 }
 
-static NSSet* _Nullable NSSetFromFStrings(const TArray<FString>& Array, bool ReturnNilForEmpty = true)
+static NSSet* _Nullable NSSetFromFStrings(const TArray<FString>& Array)
 {
-	if (ReturnNilForEmpty && Array.Num() < 1)
-	{
-		return nil;
-	}
 	NSMutableSet* Set = [NSMutableSet set];
 	for (const FString& Value : Array)
 	{
@@ -101,17 +93,29 @@ BugsnagConfiguration* FApplePlatformConfiguration::Configuration(const TSharedPt
 
 	CocoaConfig.autoTrackSessions = Configuration->GetAutoTrackSessions();
 
-	CocoaConfig.context = NSStringFromFString(Configuration->GetContext());
+	if (!Configuration->GetContext().IsEmpty())
+	{
+		CocoaConfig.context = NSStringFromFString(Configuration->GetContext());
+	}
 
-	CocoaConfig.discardClasses = NSSetFromFStrings(Configuration->GetDiscardClasses());
+	if (Configuration->GetDiscardClasses().Num())
+	{
+		CocoaConfig.discardClasses = NSSetFromFStrings(Configuration->GetDiscardClasses());
+	}
 
 	CocoaConfig.enabledBreadcrumbTypes = GetEnabledBreadcrumbTypes(Configuration->GetEnabledBreadcrumbTypes());
 
 	CocoaConfig.enabledErrorTypes = GetEnabledErrorTypes(Configuration->GetEnabledErrorTypes());
 
-	CocoaConfig.enabledReleaseStages = NSSetFromFStrings(Configuration->GetEnabledReleaseStages());
+	if (Configuration->GetEnabledReleaseStages().Num())
+	{
+		CocoaConfig.enabledReleaseStages = NSSetFromFStrings(Configuration->GetEnabledReleaseStages());
+	}
 
-	CocoaConfig.redactedKeys = NSSetFromFStrings(Configuration->GetRedactedKeys());
+	if (Configuration->GetRedactedKeys().Num())
+	{
+		CocoaConfig.redactedKeys = NSSetFromFStrings(Configuration->GetRedactedKeys());
+	}
 
 	if (Configuration->GetAppHangThresholdMillis() == FBugsnagConfiguration::AppHangThresholdFatalOnly)
 	{
@@ -136,13 +140,25 @@ BugsnagConfiguration* FApplePlatformConfiguration::Configuration(const TSharedPt
 
 	CocoaConfig.persistUser = Configuration->GetPersistUser();
 
-	CocoaConfig.releaseStage = NSStringFromFString(Configuration->GetReleaseStage());
+	if (!Configuration->GetReleaseStage().IsEmpty())
+	{
+		CocoaConfig.releaseStage = NSStringFromFString(Configuration->GetReleaseStage());
+	}
 
-	CocoaConfig.appType = NSStringFromFString(Configuration->GetAppType());
+	if (!Configuration->GetAppType().IsEmpty())
+	{
+		CocoaConfig.appType = NSStringFromFString(Configuration->GetAppType());
+	}
 
-	CocoaConfig.appVersion = NSStringFromFString(Configuration->GetAppVersion());
+	if (!Configuration->GetAppVersion().IsEmpty())
+	{
+		CocoaConfig.appVersion = NSStringFromFString(Configuration->GetAppVersion());
+	}
 
-	CocoaConfig.bundleVersion = NSStringFromFString(Configuration->GetBundleVersion());
+	if (!Configuration->GetBundleVersion().IsEmpty())
+	{
+		CocoaConfig.bundleVersion = NSStringFromFString(Configuration->GetBundleVersion());
+	}
 
 	CocoaConfig.endpoints = [[BugsnagEndpointConfiguration alloc]
 		initWithNotify:NSStringFromFString(Configuration->GetEndpoints().GetNotify())

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -41,6 +41,27 @@ void FApplePlatformConfigurationSpec::Define()
 
 	Describe("Properties", [this]()
 		{
+			It("Defaults", [this]()
+				{
+					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
+					BugsnagConfiguration* DefaultConfig = [[BugsnagConfiguration alloc] initWithApiKey:@(TCHAR_TO_UTF8(*ApiKey))];
+					TEST_TRUE(CocoaConfig.appHangThresholdMillis == DefaultConfig.appHangThresholdMillis);
+					TEST_TRUE(CocoaConfig.enabledBreadcrumbTypes == DefaultConfig.enabledBreadcrumbTypes);
+					TEST_TRUE(CocoaConfig.enabledErrorTypes.appHangs);
+					TEST_TRUE(CocoaConfig.enabledErrorTypes.cppExceptions);
+					TEST_TRUE(CocoaConfig.enabledErrorTypes.machExceptions);
+					TEST_TRUE(CocoaConfig.enabledErrorTypes.ooms);
+					TEST_TRUE(CocoaConfig.enabledErrorTypes.signals);
+					TEST_TRUE(CocoaConfig.enabledErrorTypes.thermalKills);
+					TEST_TRUE(CocoaConfig.enabledErrorTypes.unhandledExceptions);
+					TEST_TRUE([CocoaConfig.apiKey isEqual:DefaultConfig.apiKey]);
+					TEST_TRUE([CocoaConfig.appType isEqual:DefaultConfig.appType]);
+					TEST_TRUE([CocoaConfig.bundleVersion isEqual:DefaultConfig.bundleVersion]);
+					TEST_TRUE([CocoaConfig.redactedKeys isEqual:DefaultConfig.redactedKeys])
+					TEST_TRUE([CocoaConfig.releaseStage isEqual:DefaultConfig.releaseStage]);
+				});
+
 			It("ApiKey", [this]()
 				{
 					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));


### PR DESCRIPTION
## Goal

Fix a bug with how the Cocoa configuration object is set up.

Certain properties like `appType`, `bundleVersion` etc are set to their defaults in BugsnagConfiguration's initializer and should not be set to nil by default.

## Changeset

Configuration properties are now only set if the unreal config has a non-empty string or array.

## Testing

Added a test case to confirm the problem and verify the fix.