### PR TITLE
[PLAT-7258] Cocoa sessions

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/AppleBugsnagUtils.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/AppleBugsnagUtils.h
@@ -8,15 +8,29 @@
 
 #import <BugsnagPrivate/BSGJSONSerialization.h>
 
+// String conversion
+
 static inline FString FStringFromNSString(NSString* _Nullable String)
 {
 	return String ? FString(UTF8_TO_TCHAR(String.UTF8String)) : TEXT("");
 }
 
-static inline NSString* NSStringFromFString(const FString& String)
+static inline NSString* _Nonnull NSStringFromFString(const FString& String)
 {
 	return @(TCHAR_TO_UTF8(*String));
 }
+
+static inline TSharedPtr<FString> FStringPtrFromNSString(NSString* _Nullable String)
+{
+	return String ? MakeShareable(new FString(UTF8_TO_TCHAR(String.UTF8String))) : nullptr;
+}
+
+static inline NSString* _Nullable NSStringFromFStringPtr(const TSharedPtr<FString>& String)
+{
+	return String.IsValid() ? @(TCHAR_TO_UTF8(**String)) : nil;
+}
+
+// Date conversion
 
 static inline FDateTime FDateTimeFromNSDate(NSDate* Date)
 {
@@ -27,6 +41,8 @@ static inline NSDate* NSDateFromFDateTime(const FDateTime& DateTime)
 {
 	return [NSDate dateWithTimeIntervalSince1970:(DateTime.GetTicks() - FDateTime(1970, 1, 1).GetTicks()) / ETimespan::TicksPerSecond];
 }
+
+// JSON object conversion
 
 static inline TSharedPtr<FJsonObject> FJsonObjectFromNSDictionary(NSDictionary* Dictionary, NSError** Error = nil)
 {
@@ -59,6 +75,8 @@ static inline NSDictionary* _Nullable NSDictionaryFromFJsonObject(const TSharedP
 	}
 	return nil;
 }
+
+// Misc
 
 static inline NSSet* NSSetFromFStrings(const TArray<FString>& Array)
 {

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
@@ -3,6 +3,7 @@
 #include "AppleBugsnagUtils.h"
 #include "ApplePlatformConfiguration.h"
 #include "WrappedBreadcrumb.h"
+#include "WrappedSession.h"
 
 #import <Bugsnag/Bugsnag.h>
 
@@ -102,15 +103,17 @@ TSharedPtr<FBugsnagLastRunInfo> FApplePlatformBugsnag::GetLastRunInfo()
 
 void FApplePlatformBugsnag::StartSession()
 {
+	[Bugsnag startSession];
 }
 
 void FApplePlatformBugsnag::PauseSession()
 {
+	[Bugsnag pauseSession];
 }
 
 bool FApplePlatformBugsnag::ResumeSession()
 {
-	return false;
+	return [Bugsnag resumeSession];
 }
 
 void FApplePlatformBugsnag::AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback)
@@ -123,4 +126,7 @@ void FApplePlatformBugsnag::AddOnError(const FBugsnagOnErrorCallback& Callback)
 
 void FApplePlatformBugsnag::AddOnSession(const FBugsnagOnSessionCallback& Callback)
 {
+	[Bugsnag addOnSessionBlock:^BOOL(BugsnagSession* _Nonnull Session) {
+		return Callback(FWrappedSession::From(Session).Get());
+	}];
 }

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
@@ -3,6 +3,7 @@
 #include "AppleBugsnagUtils.h"
 #include "Version.h"
 #include "WrappedBreadcrumb.h"
+#include "WrappedSession.h"
 
 #import <Bugsnag/BugsnagConfiguration.h>
 #import <Bugsnag/BugsnagEndpointConfiguration.h>
@@ -170,8 +171,7 @@ BugsnagConfiguration* FApplePlatformConfiguration::Configuration(const TSharedPt
 	for (auto& Callback : Configuration->GetOnSessionCallbacks())
 	{
 		[CocoaConfig addOnSessionBlock:^BOOL(BugsnagSession* _Nonnull Session) {
-			// TODO: Convert BugsnagSession to IBugsnagSession
-			return Callback((IBugsnagSession*)nullptr);
+			return Callback(FWrappedSession::From(Session).Get());
 		}];
 	}
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/AppleBugsnagUtils.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/AppleBugsnagUtils.spec.cpp
@@ -1,32 +1,6 @@
-#include "Misc/AutomationTest.h"
+#include "AutomationTest.h"
 
 #include "Apple/AppleBugsnagUtils.h"
-
-//
-// Macros copied from Engine/Source/Developer/AutomationDriver/Private/Specs/AutomationDriver.spec.cpp
-//
-#define TEST_TRUE(expression) \
-	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, true)
-
-#define TEST_FALSE(expression) \
-	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, false)
-
-#define TEST_EQUAL(expression, expected) \
-	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, expected)
-
-#define EPIC_TEST_BOOLEAN_(text, expression, expected) \
-	TestEqual(text, expression, expected);
-
-#define TEST_EQUAL_OBJC(value, expected)                                    \
-	if (![value isEqual:expected])                                          \
-	{                                                                       \
-		AddError(                                                           \
-			FString::Printf(                                                \
-				TEXT("Expected " #value " to be %s, but it was %s"),        \
-				UTF8_TO_TCHAR(expected.description.UTF8String ?: "(null)"), \
-				UTF8_TO_TCHAR(value.description.UTF8String ?: "(null)")),   \
-			1);                                                             \
-	}
 
 BEGIN_DEFINE_SPEC(FAppleBugsnagUtilsSpec, "Bugsnag.FAppleBugsnagUtilsSpec",
 	EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
@@ -50,6 +24,33 @@ void FAppleBugsnagUtilsSpec::Define()
 					TEST_EQUAL_OBJC(NSStringFromFString(TEXT("")), @"");
 					TEST_EQUAL_OBJC(NSStringFromFString(TEXT("Hello, Unreal Engine!")), @"Hello, Unreal Engine!");
 					TEST_EQUAL_OBJC(NSStringFromFString(FString()), @"");
+				});
+		});
+
+	Describe("FStringPtrFromNSString", [this]()
+		{
+			It("Converts from NSString to TSharedPtr<FString>", [this]()
+				{
+					TEST_EQUAL(*FStringPtrFromNSString(@""), TEXT(""));
+					TEST_EQUAL(*FStringPtrFromNSString(@"Hello, Unreal Engine!"), TEXT("Hello, Unreal Engine!"));
+				});
+			It("Returns nullptr for nil", [this]()
+				{
+					TEST_FALSE(FStringPtrFromNSString(nil).IsValid());
+				});
+		});
+
+	Describe("NSStringFromFStringPtr", [this]()
+		{
+			It("Converts from TSharedPtr<FString> to NSString", [this]()
+				{
+					TEST_EQUAL_OBJC(NSStringFromFStringPtr(MakeShareable(new FString(TEXT("")))), @"");
+					TEST_EQUAL_OBJC(NSStringFromFStringPtr(MakeShareable(new FString(TEXT("Hello, Unreal Engine!")))), @"Hello, Unreal Engine!");
+					TEST_EQUAL_OBJC(NSStringFromFStringPtr(MakeShareable(new FString(FString()))), @"");
+				});
+			It("Returns nil for nullptr", [this]()
+				{
+					TEST_TRUE(NSStringFromFStringPtr(nullptr) == nil);
 				});
 		});
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -1,4 +1,4 @@
-#include "Misc/AutomationTest.h"
+#include "AutomationTest.h"
 
 #include "Apple/ApplePlatformConfiguration.h"
 #include "BugsnagConfiguration.h"
@@ -11,21 +11,6 @@
 #import <Bugsnag/BugsnagUser.h>
 
 #import <BugsnagPrivate/BugsnagConfiguration+Private.h>
-
-//
-// Macros copied from Engine/Source/Developer/AutomationDriver/Private/Specs/AutomationDriver.spec.cpp
-//
-#define TEST_TRUE(expression) \
-	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, true)
-
-#define TEST_FALSE(expression) \
-	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, false)
-
-#define TEST_EQUAL(expression, expected) \
-	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, expected)
-
-#define EPIC_TEST_BOOLEAN_(text, expression, expected) \
-	TestEqual(text, expression, expected);
 
 //
 // This is an example of an Automation Spec, a newer type of test that follows BDD methodology.
@@ -301,6 +286,9 @@ void FApplePlatformConfigurationSpec::Define()
 					bool OnSessionCalled = false;
 					Configuration->AddOnSession([&OnSessionCalled](IBugsnagSession* Session) mutable
 						{
+							Session->SetUser(TEXT("user123"));
+							Session->GetApp()->SetReleaseStage(MakeShareable(new FString(TEXT("testing"))));
+							Session->GetDevice()->SetLocale(nullptr);
 							OnSessionCalled = true;
 							return false;
 						});

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/AutomationTest.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/AutomationTest.h
@@ -1,0 +1,27 @@
+#include "Misc/AutomationTest.h"
+
+//
+// Macros copied from Engine/Source/Developer/AutomationDriver/Private/Specs/AutomationDriver.spec.cpp
+//
+#define TEST_TRUE(expression) \
+	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, true)
+
+#define TEST_FALSE(expression) \
+	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, false)
+
+#define TEST_EQUAL(expression, expected) \
+	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, expected)
+
+#define EPIC_TEST_BOOLEAN_(text, expression, expected) \
+	TestEqual(text, expression, expected);
+
+#define TEST_EQUAL_OBJC(value, expected)                                    \
+	if (![value isEqual:expected])                                          \
+	{                                                                       \
+		AddError(                                                           \
+			FString::Printf(                                                \
+				TEXT("Expected " #value " to be %s, but it was %s"),        \
+				UTF8_TO_TCHAR(expected.description.UTF8String ?: "(null)"), \
+				UTF8_TO_TCHAR(value.description.UTF8String ?: "(null)")),   \
+			1);                                                             \
+	}

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/WrappedBreadcrumb.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/WrappedBreadcrumb.spec.cpp
@@ -1,32 +1,6 @@
-#include "Misc/AutomationTest.h"
+#include "AutomationTest.h"
 
 #include "Apple/WrappedBreadcrumb.h"
-
-//
-// Macros copied from Engine/Source/Developer/AutomationDriver/Private/Specs/AutomationDriver.spec.cpp
-//
-#define TEST_TRUE(expression) \
-	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, true)
-
-#define TEST_FALSE(expression) \
-	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, false)
-
-#define TEST_EQUAL(expression, expected) \
-	EPIC_TEST_BOOLEAN_(TEXT(#expression), expression, expected)
-
-#define EPIC_TEST_BOOLEAN_(text, expression, expected) \
-	TestEqual(text, expression, expected);
-
-#define TEST_EQUAL_OBJC(value, expected)                                    \
-	if (![value isEqual:expected])                                          \
-	{                                                                       \
-		AddError(                                                           \
-			FString::Printf(                                                \
-				TEXT("Expected " #value " to be %s, but it was %s"),        \
-				UTF8_TO_TCHAR(expected.description.UTF8String ?: "(null)"), \
-				UTF8_TO_TCHAR(value.description.UTF8String ?: "(null)")),   \
-			1);                                                             \
-	}
 
 BEGIN_DEFINE_SPEC(FWrappedBreadcrumbSpec, "Bugsnag.FWrappedBreadcrumbSpec",
 	EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/WrappedDevice.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/WrappedDevice.spec.cpp
@@ -1,0 +1,76 @@
+#include "AutomationTest.h"
+
+#include "Apple/WrappedDevice.h"
+
+BEGIN_DEFINE_SPEC(FWrappedDeviceSpec, "Bugsnag.FWrappedDeviceSpec",
+	EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+END_DEFINE_SPEC(FWrappedDeviceSpec)
+void FWrappedDeviceSpec::Define()
+{
+	Describe("FWrappedDevice", [this]()
+		{
+			It("Gets values from the Cocoa object", [this]()
+				{
+					BugsnagDevice* CocoaDevice = [[BugsnagDevice alloc] init];
+					CocoaDevice.jailbroken = YES;
+					CocoaDevice.id = @"uniqueId";
+					CocoaDevice.locale = @"en_EN";
+					CocoaDevice.manufacturer = @"Apple";
+					CocoaDevice.model = @"iPhone99,9";
+					CocoaDevice.modelNumber = @"D79AP";
+					CocoaDevice.osName = @"iOS";
+					CocoaDevice.osVersion = @"14.1";
+					CocoaDevice.runtimeVersions = @{
+						@"something": @"1.0",
+						@"else": @"2.0"
+					};
+					CocoaDevice.totalMemory = @(100 * 1024 * 1024);
+
+					TSharedPtr<IBugsnagDevice> Device = FWrappedDevice::From(CocoaDevice);
+					TEST_EQUAL(*Device->GetJailbroken(), true);
+					TEST_EQUAL(*Device->GetId(), TEXT("uniqueId"));
+					TEST_EQUAL(*Device->GetLocale(), TEXT("en_EN"));
+					TEST_EQUAL(*Device->GetManufacturer(), TEXT("Apple"));
+					TEST_EQUAL(*Device->GetModel(), TEXT("iPhone99,9"));
+					TEST_EQUAL(*Device->GetModelNumber(), TEXT("D79AP"));
+					TEST_EQUAL(*Device->GetOsName(), TEXT("iOS"));
+					TEST_EQUAL(*Device->GetOsVersion(), TEXT("14.1"));
+					TSharedPtr<TMap<FString, FString>> RuntimeVersions = Device->GetRuntimeVersions();
+					TEST_EQUAL(RuntimeVersions->Num(), 2);
+					TEST_EQUAL((*RuntimeVersions)[TEXT("something")], TEXT("1.0"));
+					TEST_EQUAL((*RuntimeVersions)[TEXT("else")], TEXT("2.0"));
+					TEST_EQUAL(*Device->GetTotalMemory(), 100 * 1024 * 1024);
+				});
+
+			It("Sets values on the Cocoa object", [this]()
+				{
+					BugsnagDevice* CocoaDevice = [[BugsnagDevice alloc] init];
+
+					TSharedPtr<IBugsnagDevice> Device = FWrappedDevice::From(CocoaDevice);
+					Device->SetJailbroken(MakeShareable(new bool(true)));
+					Device->SetId(MakeShareable(new FString(TEXT("uniqueId"))));
+					Device->SetLocale(MakeShareable(new FString(TEXT("en_EN"))));
+					Device->SetManufacturer(MakeShareable(new FString(TEXT("Apple"))));
+					Device->SetModel(MakeShareable(new FString(TEXT("iPhone99,9"))));
+					Device->SetModelNumber(MakeShareable(new FString(TEXT("D79AP"))));
+					Device->SetOsName(MakeShareable(new FString(TEXT("iOS"))));
+					Device->SetOsVersion(MakeShareable(new FString(TEXT("14.1"))));
+					TSharedPtr<TMap<FString, FString>> RuntimeVersions = MakeShareable(new TMap<FString, FString>);
+					RuntimeVersions->Add(TEXT("something"), TEXT("1.0"));
+					RuntimeVersions->Add(TEXT("else"), TEXT("2.0"));
+					Device->SetRuntimeVersions(RuntimeVersions);
+					Device->SetTotalMemory(MakeShareable(new uint64(100 * 1024 * 1024)));
+
+					TEST_EQUAL(CocoaDevice.jailbroken, YES);
+					TEST_EQUAL_OBJC(CocoaDevice.id, @"uniqueId");
+					TEST_EQUAL_OBJC(CocoaDevice.locale, @"en_EN");
+					TEST_EQUAL_OBJC(CocoaDevice.manufacturer, @"Apple");
+					TEST_EQUAL_OBJC(CocoaDevice.model, @"iPhone99,9");
+					TEST_EQUAL_OBJC(CocoaDevice.modelNumber, @"D79AP");
+					TEST_EQUAL_OBJC(CocoaDevice.osName, @"iOS");
+					TEST_EQUAL_OBJC(CocoaDevice.osVersion, @"14.1");
+					TEST_EQUAL_OBJC(CocoaDevice.runtimeVersions, (@{@"something": @"1.0", @"else": @"2.0"}));
+					TEST_EQUAL_OBJC(CocoaDevice.totalMemory, @(100 * 1024 * 1024));
+				});
+		});
+}

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedApp.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedApp.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include "AppleBugsnagUtils.h"
+#include "BugsnagApp.h"
+
+#import <Bugsnag/BugsnagApp.h>
+
+class FWrappedApp : public IBugsnagApp
+{
+public:
+	static TSharedPtr<FWrappedApp> From(BugsnagApp* CocoaApp)
+	{
+		return MakeShareable(new FWrappedApp(CocoaApp));
+	}
+
+	// binaryArch?: string;
+
+	const TSharedPtr<FString> GetBinaryArch() const
+	{
+		return FStringPtrFromNSString(CocoaApp.binaryArch);
+	}
+
+	void SetBinaryArch(const TSharedPtr<FString>& Value)
+	{
+		CocoaApp.binaryArch = NSStringFromFStringPtr(Value);
+	}
+
+	// buildUuid?: string;
+
+	const TSharedPtr<FString> GetBuildUuid() const
+	{
+		// Not supported by bugsnag-cocoa
+		return nullptr;
+	}
+
+	void SetBuildUuid(const TSharedPtr<FString>&)
+	{
+		// Not supported by bugsnag-cocoa
+	}
+
+	// bundleVersion?: string;
+
+	const TSharedPtr<FString> GetBundleVersion() const
+	{
+		return FStringPtrFromNSString(CocoaApp.bundleVersion);
+	}
+
+	void SetBundleVersion(const TSharedPtr<FString>& Value)
+	{
+		CocoaApp.bundleVersion = NSStringFromFStringPtr(Value);
+	}
+
+	// dsymUuid?: string;
+
+	const TSharedPtr<FString> GetDsymUuid() const
+	{
+		return FStringPtrFromNSString(CocoaApp.dsymUuid);
+	}
+
+	void SetDsymUuid(const TSharedPtr<FString>& Value)
+	{
+		CocoaApp.dsymUuid = NSStringFromFStringPtr(Value);
+	}
+
+	// id?: string;
+
+	const TSharedPtr<FString> GetId() const
+	{
+		return FStringPtrFromNSString(CocoaApp.id);
+	}
+
+	void SetId(const TSharedPtr<FString>& Value)
+	{
+		CocoaApp.id = NSStringFromFStringPtr(Value);
+	}
+
+	// releaseStage: string = "production";
+
+	const TSharedPtr<FString> GetReleaseStage() const
+	{
+		return FStringPtrFromNSString(CocoaApp.releaseStage);
+	}
+
+	void SetReleaseStage(const TSharedPtr<FString>& Value)
+	{
+		CocoaApp.releaseStage = NSStringFromFStringPtr(Value);
+	}
+
+	// type?: string;
+
+	const TSharedPtr<FString> GetType() const
+	{
+		return FStringPtrFromNSString(CocoaApp.type);
+	}
+
+	void SetType(const TSharedPtr<FString>& Value)
+	{
+		CocoaApp.type = NSStringFromFStringPtr(Value);
+	}
+
+	// version?: string;
+
+	const TSharedPtr<FString> GetVersion() const
+	{
+		return FStringPtrFromNSString(CocoaApp.version);
+	}
+
+	void SetVersion(const TSharedPtr<FString>& Value)
+	{
+		CocoaApp.version = NSStringFromFStringPtr(Value);
+	}
+
+	// versionCode?: number;
+
+	const TSharedPtr<uint64> GetVersionCode() const
+	{
+		// Not supported by bugsnag-cocoa
+		return nullptr;
+	}
+
+	void SetVersionCode(const TSharedPtr<uint64>& Value)
+	{
+		// Not supported by bugsnag-cocoa
+	}
+
+private:
+	FWrappedApp(BugsnagApp* CocoaApp)
+		: CocoaApp(CocoaApp)
+	{
+	}
+
+	BugsnagApp* CocoaApp;
+};

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedDevice.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedDevice.h
@@ -1,0 +1,179 @@
+#pragma once
+
+#include "AppleBugsnagUtils.h"
+#include "BugsnagDevice.h"
+
+#import <Bugsnag/BugsnagDevice.h>
+
+class FWrappedDevice : public IBugsnagDevice
+{
+public:
+	static TSharedPtr<FWrappedDevice> From(BugsnagDevice* CocoaDevice)
+	{
+		return MakeShareable(new FWrappedDevice(CocoaDevice));
+	}
+
+	// cpuAbi?: string[];
+
+	const TSharedPtr<TArray<FString>> GetCpuAbi() const
+	{
+		// Not supported by bugsnag-cocoa
+		return nullptr;
+	}
+
+	void SetCpuAbi(const TSharedPtr<TArray<FString>>&)
+	{
+		// Not supported by bugsnag-cocoa
+	}
+
+	// id?: string;
+
+	const TSharedPtr<FString> GetId() const
+	{
+		return FStringPtrFromNSString(CocoaDevice.id);
+	}
+
+	void SetId(const TSharedPtr<FString>& Value)
+	{
+		CocoaDevice.id = NSStringFromFStringPtr(Value);
+	}
+
+	// jailbroken?: boolean;
+
+	TSharedPtr<bool> GetJailbroken() const
+	{
+		return MakeShareable(new bool(CocoaDevice.jailbroken));
+	}
+
+	void SetJailbroken(const TSharedPtr<bool>& Value)
+	{
+		CocoaDevice.jailbroken = Value.IsValid() && *Value;
+	}
+
+	// locale?: string;
+
+	const TSharedPtr<FString> GetLocale() const
+	{
+		return FStringPtrFromNSString(CocoaDevice.locale);
+	}
+
+	void SetLocale(const TSharedPtr<FString>& Value)
+	{
+		CocoaDevice.locale = NSStringFromFStringPtr(Value);
+	}
+
+	// modelNumber?: string;
+
+	const TSharedPtr<FString> GetModelNumber() const
+	{
+		return FStringPtrFromNSString(CocoaDevice.modelNumber);
+	}
+
+	void SetModelNumber(const TSharedPtr<FString>& Value)
+	{
+		CocoaDevice.modelNumber = NSStringFromFStringPtr(Value);
+	}
+
+	// manufacturer?: string;
+
+	const TSharedPtr<FString> GetManufacturer() const
+	{
+		return FStringPtrFromNSString(CocoaDevice.manufacturer);
+	}
+
+	void SetManufacturer(const TSharedPtr<FString>& Value)
+	{
+		CocoaDevice.manufacturer = NSStringFromFStringPtr(Value);
+	}
+
+	// model?: string;
+
+	const TSharedPtr<FString> GetModel() const
+	{
+		return FStringPtrFromNSString(CocoaDevice.model);
+	}
+
+	void SetModel(const TSharedPtr<FString>& Value)
+	{
+		CocoaDevice.model = NSStringFromFStringPtr(Value);
+	}
+
+	// osName?: string;
+
+	const TSharedPtr<FString> GetOsName() const
+	{
+		return FStringPtrFromNSString(CocoaDevice.osName);
+	}
+
+	void SetOsName(const TSharedPtr<FString>& Value)
+	{
+		CocoaDevice.osName = NSStringFromFStringPtr(Value);
+	}
+
+	// osVersion?: string;
+
+	const TSharedPtr<FString> GetOsVersion() const
+	{
+		return FStringPtrFromNSString(CocoaDevice.osVersion);
+	}
+
+	void SetOsVersion(const TSharedPtr<FString>& Value)
+	{
+		CocoaDevice.osVersion = NSStringFromFStringPtr(Value);
+	}
+
+	// runtimeVersions?: map[string->string];
+
+	const TSharedPtr<TMap<FString, FString>> GetRuntimeVersions() const
+	{
+		if (!CocoaDevice.runtimeVersions)
+		{
+			return nullptr;
+		}
+		TSharedPtr<TMap<FString, FString>> RuntimeVersions = MakeShareable(new TMap<FString, FString>);
+		for (NSString* Key in CocoaDevice.runtimeVersions)
+		{
+			id Value = CocoaDevice.runtimeVersions[Key];
+			if ([Value isKindOfClass:[NSString class]])
+			{
+				RuntimeVersions->Add(FStringFromNSString(Key), FStringFromNSString(Value));
+			}
+		}
+		return RuntimeVersions;
+	}
+
+	void SetRuntimeVersions(const TSharedPtr<TMap<FString, FString>>& Value)
+	{
+		if (!Value.IsValid())
+		{
+			CocoaDevice.runtimeVersions = nil;
+			return;
+		}
+		NSMutableDictionary* Dictionary = [NSMutableDictionary dictionary];
+		for (const TPair<FString, FString>& Pair : *Value)
+		{
+			Dictionary[NSStringFromFString(Pair.Key)] = NSStringFromFString(Pair.Value);
+		}
+		CocoaDevice.runtimeVersions = Dictionary;
+	}
+
+	// totalMemory?: number;
+
+	const TSharedPtr<uint64> GetTotalMemory() const
+	{
+		return CocoaDevice.totalMemory ? MakeShareable(new uint64(CocoaDevice.totalMemory.unsignedLongValue)) : nullptr;
+	}
+
+	void SetTotalMemory(const TSharedPtr<uint64>& Value)
+	{
+		CocoaDevice.totalMemory = Value.IsValid() ? @(*Value) : nil;
+	}
+
+private:
+	FWrappedDevice(BugsnagDevice* CocoaDevice)
+		: CocoaDevice(CocoaDevice)
+	{
+	}
+
+	BugsnagDevice* CocoaDevice;
+};

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedSession.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedSession.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "AppleBugsnagUtils.h"
+#include "BugsnagSession.h"
+#include "WrappedApp.h"
+#include "WrappedDevice.h"
+
+#import <Bugsnag/BugsnagSession.h>
+
+class FWrappedSession : public IBugsnagSession
+{
+public:
+	static TSharedPtr<FWrappedSession> From(BugsnagSession* CocoaSession)
+	{
+		return MakeShareable(new FWrappedSession(CocoaSession));
+	}
+
+	const FString GetId() const
+	{
+		return FStringFromNSString(CocoaSession.id);
+	}
+
+	void SetId(const FString& Id)
+	{
+		CocoaSession.id = NSStringFromFString(Id);
+	}
+
+	const FDateTime GetStartedAt() const
+	{
+		return FDateTimeFromNSDate(CocoaSession.startedAt);
+	}
+
+	void SetStartedAt(const FDateTime& StartedAt)
+	{
+		CocoaSession.startedAt = NSDateFromFDateTime(StartedAt);
+	}
+
+	TSharedPtr<IBugsnagApp> GetApp()
+	{
+		return FWrappedApp::From(CocoaSession.app);
+	}
+
+	TSharedPtr<IBugsnagDevice> GetDevice()
+	{
+		return FWrappedDevice::From(CocoaSession.device);
+	}
+
+	const FBugsnagUser GetUser() const
+	{
+		return FBugsnagUser(
+			FStringFromNSString(CocoaSession.user.id),
+			FStringFromNSString(CocoaSession.user.email),
+			FStringFromNSString(CocoaSession.user.name));
+	}
+
+	void SetUser(const FString& Id = TEXT(""), const FString& Email = TEXT(""), const FString& Name = TEXT(""))
+	{
+		[CocoaSession setUser:NSStringFromFString(Id)
+					withEmail:NSStringFromFString(Email)
+					  andName:NSStringFromFString(Name)];
+	}
+
+private:
+	FWrappedSession(BugsnagSession* CocoaSession)
+		: CocoaSession(CocoaSession)
+	{
+	}
+
+	BugsnagSession* CocoaSession;
+};


### PR DESCRIPTION
## Goal

Implement `OnSession` and session related APIs.

## Changeset

`FWrappedSession` implements the C++ wrapper around the Cocoa session object.

Wrapper objects have been created for `app` and `device` which are children of a session.

## Testing

Unit tests verify that device objects can be accessed and modified through the wrapper (to test the handling of RuntimeVersions in particular).

The `OnSession` block unit test performs some basic validation that getters and setters can be used.