### PR TITLE
set and validate android config options

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -14,6 +14,7 @@
         "jfield",
         "jmethod",
         "jobject",
+        "jboolean",
         "Lcom",
         "Ljava"
     ],

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
@@ -23,14 +23,14 @@ static jclass LoadJavaClass(JNIEnv* env, const char* qualified_name, bool use_he
 	return (jclass)(*env).NewGlobalRef((*env).FindClass(qualified_name));
 }
 
-#define CheckNonNull(env, var)     \
-	if (var == NULL)               \
-	{                              \
-		if (env->ExceptionCheck()) \
-		{                          \
-			env->ExceptionClear(); \
-		}                          \
-		return false;              \
+#define ReturnFalseIfNullAndClearExceptions(env, var) \
+	if (var == NULL)                                  \
+	{                                                 \
+		if (env->ExceptionCheck())                    \
+		{                                             \
+			env->ExceptionClear();                    \
+		}                                             \
+		return false;                                 \
 	}
 
 bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cache)
@@ -42,35 +42,122 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 
 	// Third-party classes are loaded via a class loader accessible to the Unreal JNI helpers
 	cache->BugsnagClass = LoadJavaClass(env, "com.bugsnag.android.Bugsnag", true);
-	CheckNonNull(env, cache->BugsnagClass);
+	ReturnFalseIfNullAndClearExceptions(env, cache->BugsnagClass);
 	cache->ConfigClass = LoadJavaClass(env, "com.bugsnag.android.Configuration", true);
-	CheckNonNull(env, cache->ConfigClass);
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigClass);
 	cache->InterfaceClass = LoadJavaClass(env, "com.bugsnag.android.NativeInterface", true);
-	CheckNonNull(env, cache->InterfaceClass);
+	ReturnFalseIfNullAndClearExceptions(env, cache->InterfaceClass);
+	cache->BreadcrumbTypeClass = LoadJavaClass(env, "com.bugsnag.android.BreadcrumbType", true);
+	ReturnFalseIfNullAndClearExceptions(env, cache->BreadcrumbTypeClass);
 	cache->SeverityClass = LoadJavaClass(env, "com.bugsnag.android.Severity", true);
-	CheckNonNull(env, cache->SeverityClass);
+	ReturnFalseIfNullAndClearExceptions(env, cache->SeverityClass);
+	cache->EndpointConfigurationClass = LoadJavaClass(env, "com.bugsnag.android.EndpointConfiguration", true);
+	ReturnFalseIfNullAndClearExceptions(env, cache->EndpointConfigurationClass);
+	cache->ErrorTypesClass = LoadJavaClass(env, "com.bugsnag.android.ErrorTypes", true);
+	ReturnFalseIfNullAndClearExceptions(env, cache->ErrorTypesClass);
+	cache->ThreadSendPolicyClass = LoadJavaClass(env, "com.bugsnag.android.ThreadSendPolicy", true);
+	ReturnFalseIfNullAndClearExceptions(env, cache->ThreadSendPolicyClass);
 
 	// Core classes are available through standard JNI functions only
+	cache->HashSetClass = LoadJavaClass(env, "java/util/HashSet", false);
+	ReturnFalseIfNullAndClearExceptions(env, cache->HashSetClass);
 	cache->TraceClass = LoadJavaClass(env, "java/lang/StackTraceElement", false);
-	CheckNonNull(env, cache->TraceClass);
+	ReturnFalseIfNullAndClearExceptions(env, cache->TraceClass);
 
 	cache->BugsnagStartMethod = (*env).GetStaticMethodID(cache->BugsnagClass, "start",
 		"(Landroid/content/Context;Lcom/bugsnag/android/Configuration;)Lcom/bugsnag/android/Client;");
-	CheckNonNull(env, cache->BugsnagStartMethod);
+	ReturnFalseIfNullAndClearExceptions(env, cache->BugsnagStartMethod);
 	cache->BugsnagNotifyMethod = (*env).GetStaticMethodID(cache->InterfaceClass, "notify",
 		"([B[BLcom/bugsnag/android/Severity;[Ljava/lang/StackTraceElement;)V");
-	CheckNonNull(env, cache->BugsnagNotifyMethod);
+	ReturnFalseIfNullAndClearExceptions(env, cache->BugsnagNotifyMethod);
+
 	cache->ConfigConstructor = (*env).GetMethodID(cache->ConfigClass, "<init>",
 		"(Ljava/lang/String;)V");
-	CheckNonNull(env, cache->ConfigConstructor);
-	cache->ConfigSetApiKey = (*env).GetMethodID(cache->ConfigClass, "setApiKey",
-		"(Ljava/lang/String;)V");
-	CheckNonNull(env, cache->ConfigSetApiKey);
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigConstructor);
+	cache->ConfigAddMetadata = (*env).GetMethodID(cache->ConfigClass, "addMetadata", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigAddMetadata);
+	cache->ConfigSetAppType = (*env).GetMethodID(cache->ConfigClass, "setAppType", "(Ljava/lang/String;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetAppType);
+	cache->ConfigSetAppVersion = (*env).GetMethodID(cache->ConfigClass, "setAppVersion", "(Ljava/lang/String;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetAppVersion);
+	cache->ConfigSetAutoDetectErrors = (*env).GetMethodID(cache->ConfigClass, "setAutoDetectErrors", "(Z)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetAutoDetectErrors);
+	cache->ConfigSetAutoTrackSessions = (*env).GetMethodID(cache->ConfigClass, "setAutoTrackSessions", "(Z)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetAutoTrackSessions);
+	cache->ConfigSetContext = (*env).GetMethodID(cache->ConfigClass, "setContext", "(Ljava/lang/String;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetContext);
+	cache->ConfigSetDiscardClasses = (*env).GetMethodID(cache->ConfigClass, "setDiscardClasses", "(Ljava/util/Set;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetDiscardClasses);
+	cache->ConfigSetEnabledBreadcrumbTypes = (*env).GetMethodID(cache->ConfigClass, "setEnabledBreadcrumbTypes", "(Ljava/util/Set;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetEnabledBreadcrumbTypes);
+	cache->ConfigSetEnabledErrorTypes = (*env).GetMethodID(cache->ConfigClass, "setEnabledErrorTypes", "(Lcom/bugsnag/android/ErrorTypes;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetEnabledErrorTypes);
+	cache->ConfigSetEnabledReleaseStages = (*env).GetMethodID(cache->ConfigClass, "setEnabledReleaseStages", "(Ljava/util/Set;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetEnabledReleaseStages);
+	cache->ConfigSetEndpoints = (*env).GetMethodID(cache->ConfigClass, "setEndpoints", "(Lcom/bugsnag/android/EndpointConfiguration;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetEndpoints);
+	cache->ConfigSetLaunchDurationMillis = (*env).GetMethodID(cache->ConfigClass, "setLaunchDurationMillis", "(J)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetLaunchDurationMillis);
+	cache->ConfigSetMaxBreadcrumbs = (*env).GetMethodID(cache->ConfigClass, "setMaxBreadcrumbs", "(I)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetMaxBreadcrumbs);
+	cache->ConfigSetMaxPersistedEvents = (*env).GetMethodID(cache->ConfigClass, "setMaxPersistedEvents", "(I)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetMaxPersistedEvents);
+	cache->ConfigSetPersistUser = (*env).GetMethodID(cache->ConfigClass, "setPersistUser", "(Z)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetPersistUser);
+	cache->ConfigSetRedactedKeys = (*env).GetMethodID(cache->ConfigClass, "setRedactedKeys", "(Ljava/util/Set;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetRedactedKeys);
+	cache->ConfigSetReleaseStage = (*env).GetMethodID(cache->ConfigClass, "setReleaseStage", "(Ljava/lang/String;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetReleaseStage);
+	cache->ConfigSetSendLaunchCrashesSynchronously = (*env).GetMethodID(cache->ConfigClass, "setSendLaunchCrashesSynchronously", "(Z)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetSendLaunchCrashesSynchronously);
+	cache->ConfigSetSendThreads = (*env).GetMethodID(cache->ConfigClass, "setSendThreads", "(Lcom/bugsnag/android/ThreadSendPolicy;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetSendThreads);
+	cache->ConfigSetUser = (*env).GetMethodID(cache->ConfigClass, "setUser", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ConfigSetUser);
+
+	cache->EndpointConfigurationConstructor = (*env).GetMethodID(cache->EndpointConfigurationClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->EndpointConfigurationConstructor);
+
+	cache->ErrorTypesConstructor = (*env).GetMethodID(cache->ErrorTypesClass, "<init>", "(ZZZZ)V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ErrorTypesConstructor);
+
+	cache->HashSetConstructor = (*env).GetMethodID(cache->HashSetClass, "<init>", "()V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->HashSetConstructor);
+	cache->HashSetAdd = (*env).GetMethodID(cache->HashSetClass, "add", "(Ljava/lang/Object;)Z");
+	ReturnFalseIfNullAndClearExceptions(env, cache->HashSetAdd);
+
 	cache->TraceConstructor = (*env).GetMethodID(cache->TraceClass, "<init>",
 		"(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V");
-	CheckNonNull(env, cache->TraceConstructor);
-	cache->SeverityField = (*env).GetStaticFieldID(cache->SeverityClass, "WARNING", "Lcom/bugsnag/android/Severity;");
-	CheckNonNull(env, cache->SeverityField);
+	ReturnFalseIfNullAndClearExceptions(env, cache->TraceConstructor);
+	cache->SeverityFieldInfo = (*env).GetStaticFieldID(cache->SeverityClass, "INFO", "Lcom/bugsnag/android/Severity;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->SeverityFieldInfo);
+	cache->SeverityFieldWarning = (*env).GetStaticFieldID(cache->SeverityClass, "WARNING", "Lcom/bugsnag/android/Severity;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->SeverityFieldWarning);
+	cache->SeverityFieldError = (*env).GetStaticFieldID(cache->SeverityClass, "ERROR", "Lcom/bugsnag/android/Severity;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->SeverityFieldError);
+	cache->BreadcrumbTypeError = (*env).GetStaticFieldID(cache->BreadcrumbTypeClass, "ERROR", "Lcom/bugsnag/android/BreadcrumbType;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BreadcrumbTypeError);
+	cache->BreadcrumbTypeLog = (*env).GetStaticFieldID(cache->BreadcrumbTypeClass, "LOG", "Lcom/bugsnag/android/BreadcrumbType;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BreadcrumbTypeLog);
+	cache->BreadcrumbTypeManual = (*env).GetStaticFieldID(cache->BreadcrumbTypeClass, "MANUAL", "Lcom/bugsnag/android/BreadcrumbType;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BreadcrumbTypeManual);
+	cache->BreadcrumbTypeNavigation = (*env).GetStaticFieldID(cache->BreadcrumbTypeClass, "NAVIGATION", "Lcom/bugsnag/android/BreadcrumbType;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BreadcrumbTypeNavigation);
+	cache->BreadcrumbTypeProcess = (*env).GetStaticFieldID(cache->BreadcrumbTypeClass, "PROCESS", "Lcom/bugsnag/android/BreadcrumbType;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BreadcrumbTypeProcess);
+	cache->BreadcrumbTypeRequest = (*env).GetStaticFieldID(cache->BreadcrumbTypeClass, "REQUEST", "Lcom/bugsnag/android/BreadcrumbType;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BreadcrumbTypeRequest);
+	cache->BreadcrumbTypeState = (*env).GetStaticFieldID(cache->BreadcrumbTypeClass, "STATE", "Lcom/bugsnag/android/BreadcrumbType;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BreadcrumbTypeState);
+	cache->BreadcrumbTypeUser = (*env).GetStaticFieldID(cache->BreadcrumbTypeClass, "USER", "Lcom/bugsnag/android/BreadcrumbType;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BreadcrumbTypeUser);
+
+	cache->ThreadSendPolicyAlways = (*env).GetStaticFieldID(cache->ThreadSendPolicyClass, "ALWAYS", "Lcom/bugsnag/android/ThreadSendPolicy;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ThreadSendPolicyAlways);
+	cache->ThreadSendPolicyUnhandledOnly = (*env).GetStaticFieldID(cache->ThreadSendPolicyClass, "UNHANDLED_ONLY", "Lcom/bugsnag/android/ThreadSendPolicy;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ThreadSendPolicyUnhandledOnly);
+	cache->ThreadSendPolicyNever = (*env).GetStaticFieldID(cache->ThreadSendPolicyClass, "NEVER", "Lcom/bugsnag/android/ThreadSendPolicy;");
+	ReturnFalseIfNullAndClearExceptions(env, cache->ThreadSendPolicyNever);
 
 	return true;
 }
@@ -98,4 +185,105 @@ bool FAndroidPlatformJNI::CheckAndClearException(JNIEnv* Env)
 		return true;
 	}
 	return false;
+}
+
+jboolean FAndroidPlatformJNI::ParseBoolean(bool value)
+{
+	return value ? JNI_TRUE : JNI_FALSE;
+}
+
+jobject FAndroidPlatformJNI::ParseStringSet(JNIEnv* Env, const JNIReferenceCache* Cache, const TArray<FString>& Values)
+{
+	jobject jSet = (*Env).NewObject(Cache->HashSetClass, Cache->HashSetConstructor);
+	if (FAndroidPlatformJNI::CheckAndClearException(Env))
+	{
+		return nullptr;
+	}
+	for (const FString& Item : Values)
+	{
+		jstring jStr = FAndroidPlatformJNI::ParseFString(Env, Item);
+		if (jStr)
+		{
+			(*Env).CallBooleanMethod(jSet, Cache->HashSetAdd, jStr);
+			if (FAndroidPlatformJNI::CheckAndClearException(Env))
+			{
+				return nullptr;
+			}
+		}
+	}
+	return jSet;
+}
+
+/**
+ * Adds a value to a set if enabled
+ *
+ * @param Env       A JNI environment for the current thread
+ * @param ShouldAdd true if the value should be added
+ * @param TypeClass the enum class
+ * @param FieldName the name of the field to add to the set
+ *
+ * @return true if operation completed without error
+ */
+static bool addTypeToSet(JNIEnv* Env, jobject jSet, bool ShouldAdd, const JNIReferenceCache* Cache, jfieldID FieldName)
+{
+	if (ShouldAdd)
+	{
+		jobject jType = (*Env).GetStaticObjectField(Cache->BreadcrumbTypeClass, FieldName);
+		if (FAndroidPlatformJNI::CheckAndClearException(Env))
+		{
+			return false;
+		}
+		(*Env).CallBooleanMethod(jSet, Cache->HashSetAdd, jType);
+		if (FAndroidPlatformJNI::CheckAndClearException(Env))
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+jobject FAndroidPlatformJNI::ParseBreadcrumbTypeSet(JNIEnv* Env, const JNIReferenceCache* Cache, const FBugsnagEnabledBreadcrumbTypes Value)
+{
+	jobject jSet = (*Env).NewObject(Cache->HashSetClass, Cache->HashSetConstructor);
+	if (FAndroidPlatformJNI::CheckAndClearException(Env))
+	{
+		return nullptr;
+	}
+	if (addTypeToSet(Env, jSet, Value.bError, Cache, Cache->BreadcrumbTypeError) &&
+		addTypeToSet(Env, jSet, Value.bLog, Cache, Cache->BreadcrumbTypeLog) &&
+		addTypeToSet(Env, jSet, Value.bManual, Cache, Cache->BreadcrumbTypeManual) &&
+		addTypeToSet(Env, jSet, Value.bNavigation, Cache, Cache->BreadcrumbTypeNavigation) &&
+		addTypeToSet(Env, jSet, Value.bProcess, Cache, Cache->BreadcrumbTypeProcess) &&
+		addTypeToSet(Env, jSet, Value.bRequest, Cache, Cache->BreadcrumbTypeRequest) &&
+		addTypeToSet(Env, jSet, Value.bState, Cache, Cache->BreadcrumbTypeState) &&
+		addTypeToSet(Env, jSet, Value.bUser, Cache, Cache->BreadcrumbTypeUser))
+	{
+		return jSet;
+	}
+	return nullptr;
+}
+
+jobject FAndroidPlatformJNI::ParseThreadSendPolicy(JNIEnv* Env, const JNIReferenceCache* Cache, const EBugsnagSendThreadsPolicy Policy)
+{
+	jfieldID FieldName;
+	switch (Policy)
+	{
+	case EBugsnagSendThreadsPolicy::All:
+		FieldName = Cache->ThreadSendPolicyAlways;
+		break;
+	case EBugsnagSendThreadsPolicy::Never:
+		FieldName = Cache->ThreadSendPolicyNever;
+		break;
+	case EBugsnagSendThreadsPolicy::UnhandledOnly:
+		FieldName = Cache->ThreadSendPolicyUnhandledOnly;
+		break;
+	default:
+		return nullptr;
+	}
+	jobject jPolicy = (*Env).GetStaticObjectField(Cache->ThreadSendPolicyClass, FieldName);
+	if (FAndroidPlatformJNI::CheckAndClearException(Env))
+	{
+		return nullptr;
+	}
+	return jPolicy;
 }

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -2,23 +2,66 @@
 
 #include <jni.h>
 
+#include "BugsnagSettings.h"
+
 typedef struct
 {
 	bool loaded;
 	bool initialized;
 	jclass InterfaceClass;
+	jclass BreadcrumbTypeClass;
 	jclass BugsnagClass;
-	jclass TraceClass;
 	jclass ConfigClass;
+	jclass EndpointConfigurationClass;
+	jclass ErrorTypesClass;
+	jclass ThreadSendPolicyClass;
 	jclass SeverityClass;
+	jclass TraceClass;
+	jclass HashSetClass;
 
 	jmethodID BugsnagStartMethod;
 	jmethodID BugsnagNotifyMethod;
+	jmethodID ConfigAddMetadata;
 	jmethodID ConfigConstructor;
-	jmethodID ConfigSetApiKey;
+	jmethodID ConfigSetAppType;
+	jmethodID ConfigSetAppVersion;
+	jmethodID ConfigSetAutoDetectErrors;
+	jmethodID ConfigSetAutoTrackSessions;
+	jmethodID ConfigSetContext;
+	jmethodID ConfigSetDiscardClasses;
+	jmethodID ConfigSetEnabledBreadcrumbTypes;
+	jmethodID ConfigSetEnabledErrorTypes;
+	jmethodID ConfigSetEnabledReleaseStages;
+	jmethodID ConfigSetEndpoints;
+	jmethodID ConfigSetLaunchDurationMillis;
+	jmethodID ConfigSetMaxBreadcrumbs;
+	jmethodID ConfigSetMaxPersistedEvents;
+	jmethodID ConfigSetPersistUser;
+	jmethodID ConfigSetRedactedKeys;
+	jmethodID ConfigSetReleaseStage;
+	jmethodID ConfigSetSendLaunchCrashesSynchronously;
+	jmethodID ConfigSetSendThreads;
+	jmethodID ConfigSetUser;
+	jmethodID EndpointConfigurationConstructor;
+	jmethodID ErrorTypesConstructor;
+	jmethodID HashSetConstructor;
+	jmethodID HashSetAdd;
 	jmethodID TraceConstructor;
 
-	jfieldID SeverityField;
+	jfieldID SeverityFieldInfo;
+	jfieldID SeverityFieldWarning;
+	jfieldID SeverityFieldError;
+	jfieldID BreadcrumbTypeError;
+	jfieldID BreadcrumbTypeLog;
+	jfieldID BreadcrumbTypeManual;
+	jfieldID BreadcrumbTypeNavigation;
+	jfieldID BreadcrumbTypeProcess;
+	jfieldID BreadcrumbTypeRequest;
+	jfieldID BreadcrumbTypeState;
+	jfieldID BreadcrumbTypeUser;
+	jfieldID ThreadSendPolicyAlways;
+	jfieldID ThreadSendPolicyUnhandledOnly;
+	jfieldID ThreadSendPolicyNever;
 } JNIReferenceCache;
 
 class FAndroidPlatformJNI
@@ -44,6 +87,48 @@ public:
    * @return a Java String reference or NULL upon failure
    */
 	static jstring ParseFString(JNIEnv* Env, const FString& Text);
+
+	/**
+   * Convert a bool value into a Java boolean
+   *
+   * @param value The boolean value
+   *
+   * @return JNI true or false value
+   */
+	static jboolean ParseBoolean(bool value);
+
+	/**
+   * Convert an array of strings into a Java Set
+   *
+   * @param Env    A JNI environment for the current thread
+   * @param Cache  A reference to a cache object to populate. Must not be null.
+   * @param Values The array to convert
+   *
+   * @return A Java object reference or null on failure
+   */
+	static jobject ParseStringSet(JNIEnv* Env, const JNIReferenceCache* Cache, const TArray<FString>& Values);
+
+	/**
+   * Convert enabled breadcrumb types into Set<BreadcrumbType>
+   *
+   * @param Env   A JNI environment for the current thread
+   * @param Cache A reference to a cache object to populate. Must not be null.
+   * @param Value The enabled types to convert
+   *
+   * @return A Java object reference or null on failure
+   */
+	static jobject ParseBreadcrumbTypeSet(JNIEnv* Env, const JNIReferenceCache* Cache, const FBugsnagEnabledBreadcrumbTypes Value);
+
+	/**
+   * Convert a value into a Java ThreadSendPolicy
+   *
+   * @param Env    A JNI environment for the current thread
+   * @param Cache  A reference to a cache object to populate. Must not be null.
+   * @param Policy The policy to convert
+   *
+   * @return A Java object reference or null on failure
+   */
+	static jobject ParseThreadSendPolicy(JNIEnv* Env, const JNIReferenceCache* Cache, const EBugsnagSendThreadsPolicy Policy);
 
 	/**
    * Check if a Java runtime exception was thrown and if so, clear it.


### PR DESCRIPTION
## Goal

Support setting (nearly) all config options, validating each value before continuing on or exiting immediately.

## Design

Used a small amount of macros for fast fails, because almost any Java Native Interface call can fail and leave the app in a broken, next-call-will-crash state. Intentionally omitted metadata and callbacks, as each required a changeset > 400 lines.

This should have been more than enough to wire up the e2e tests, but I'm still debugging what's going on with scenario selection at launch.

## Known issues

* Setting context in config does not apply to C/C++ crashes (raised an issue)

## Changeset

* Added helpers to JNI utilities to convert between arrays and Java sets of strings and enums, boolean types, and send thread values
* Set each config option from `FAndroidPlatformConfiguration`, noting the omissions as `TODO`s

## Testing

* Tested each option manually