### PR TITLE
Use TSharedRef for non-nullable values

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
@@ -87,7 +87,7 @@ void FAndroidPlatformBugsnag::LeaveBreadcrumb(const FString& Message, const TSha
 {
 }
 
-TArray<TSharedPtr<const class IBugsnagBreadcrumb>> FAndroidPlatformBugsnag::GetBreadcrumbs()
+TArray<TSharedRef<const class IBugsnagBreadcrumb>> FAndroidPlatformBugsnag::GetBreadcrumbs()
 {
 	return {};
 }

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
@@ -38,7 +38,7 @@ public:
 
 	void LeaveBreadcrumb(const FString& Message, const TSharedPtr<FJsonObject>& Metadata, EBugsnagBreadcrumbType Type) override;
 
-	TArray<TSharedPtr<const class IBugsnagBreadcrumb>> GetBreadcrumbs() override;
+	TArray<TSharedRef<const class IBugsnagBreadcrumb>> GetBreadcrumbs() override;
 
 	void MarkLaunchCompleted() override;
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
@@ -42,7 +42,7 @@ static void NotifyInternal(
 	const FString& ErrorClass,
 	const FString& Message,
 	const TArray<uint64>& StackTrace,
-	const FBugsnagOnErrorCallback& Callback = [](IBugsnagEvent*)
+	const FBugsnagOnErrorCallback& Callback = [](TSharedRef<IBugsnagEvent>)
 	{
 		return true;
 	})
@@ -82,8 +82,7 @@ static void NotifyInternal(
 	Event.context = Client.context;
 
 	[Client notifyInternal:Event block:^BOOL(BugsnagEvent* _Nonnull CocoaEvent) {
-		// TODO: Convert BugsnagEvent to IBugsnagEvent
-		return Callback((IBugsnagEvent*)nullptr);
+		return true; // TODO: Callback(FWrappedEvent::From(CocoaEvent));
 	}];
 }
 
@@ -159,9 +158,9 @@ void FApplePlatformBugsnag::LeaveBreadcrumb(const FString& Message, const TShare
 								andType:FWrappedBreadcrumb::ConvertType(Type)];
 }
 
-TArray<TSharedPtr<const IBugsnagBreadcrumb>> FApplePlatformBugsnag::GetBreadcrumbs()
+TArray<TSharedRef<const IBugsnagBreadcrumb>> FApplePlatformBugsnag::GetBreadcrumbs()
 {
-	TArray<TSharedPtr<const IBugsnagBreadcrumb>> Result;
+	TArray<TSharedRef<const IBugsnagBreadcrumb>> Result;
 	for (BugsnagBreadcrumb* Breadcrumb in Bugsnag.breadcrumbs)
 	{
 		Result.Add(FWrappedBreadcrumb::From(Breadcrumb));
@@ -204,6 +203,6 @@ void FApplePlatformBugsnag::AddOnError(const FBugsnagOnErrorCallback& Callback)
 void FApplePlatformBugsnag::AddOnSession(const FBugsnagOnSessionCallback& Callback)
 {
 	[Bugsnag addOnSessionBlock:^BOOL(BugsnagSession* _Nonnull Session) {
-		return Callback(FWrappedSession::From(Session).Get());
+		return Callback(FWrappedSession::From(Session));
 	}];
 }

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.h
@@ -38,7 +38,7 @@ public:
 
 	void LeaveBreadcrumb(const FString& Message, const TSharedPtr<FJsonObject>& Metadata, EBugsnagBreadcrumbType Type) override;
 
-	TArray<TSharedPtr<const IBugsnagBreadcrumb>> GetBreadcrumbs() override;
+	TArray<TSharedRef<const IBugsnagBreadcrumb>> GetBreadcrumbs() override;
 
 	void MarkLaunchCompleted() override;
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
@@ -156,22 +156,21 @@ BugsnagConfiguration* FApplePlatformConfiguration::Configuration(const TSharedPt
 	for (auto& Callback : Configuration->GetOnBreadcrumbCallbacks())
 	{
 		[CocoaConfig addOnBreadcrumbBlock:^BOOL(BugsnagBreadcrumb* _Nonnull Breadcrumb) {
-			return Callback(FWrappedBreadcrumb::From(Breadcrumb).Get());
+			return Callback(FWrappedBreadcrumb::From(Breadcrumb));
 		}];
 	}
 
 	for (auto& Callback : Configuration->GetOnSendErrorCallbacks())
 	{
 		[CocoaConfig addOnSendErrorBlock:^BOOL(BugsnagEvent* _Nonnull Event) {
-			// TODO: Convert BugsnagEvent to IBugsnagEvent
-			return Callback((IBugsnagEvent*)nullptr);
+			return true; // TODO: Callback(FWrappedEvent::From(Event));
 		}];
 	}
 
 	for (auto& Callback : Configuration->GetOnSessionCallbacks())
 	{
 		[CocoaConfig addOnSessionBlock:^BOOL(BugsnagSession* _Nonnull Session) {
-			return Callback(FWrappedSession::From(Session).Get());
+			return Callback(FWrappedSession::From(Session));
 		}];
 	}
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -269,7 +269,7 @@ void FApplePlatformConfigurationSpec::Define()
 					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
 
 					bool OnBreadcrumbCalled = false;
-					Configuration->AddOnBreadcrumb([&OnBreadcrumbCalled](IBugsnagBreadcrumb* Breadcrumb) mutable
+					Configuration->AddOnBreadcrumb([&OnBreadcrumbCalled](TSharedRef<IBugsnagBreadcrumb> Breadcrumb) mutable
 						{
 							Breadcrumb->SetMessage(TEXT("I'm going to ignore you"));
 							OnBreadcrumbCalled = true;
@@ -277,14 +277,14 @@ void FApplePlatformConfigurationSpec::Define()
 						});
 
 					bool OnSendErrorCalled = false;
-					Configuration->AddOnSendError([&OnSendErrorCalled](IBugsnagEvent* Error) mutable
+					Configuration->AddOnSendError([&OnSendErrorCalled](TSharedRef<IBugsnagEvent> Error) mutable
 						{
 							OnSendErrorCalled = true;
 							return false;
 						});
 
 					bool OnSessionCalled = false;
-					Configuration->AddOnSession([&OnSessionCalled](IBugsnagSession* Session) mutable
+					Configuration->AddOnSession([&OnSessionCalled](TSharedRef<IBugsnagSession> Session) mutable
 						{
 							Session->SetUser(TEXT("user123"));
 							Session->GetApp()->SetReleaseStage(MakeShareable(new FString(TEXT("testing"))));

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/WrappedDevice.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/WrappedDevice.spec.cpp
@@ -26,7 +26,7 @@ void FWrappedDeviceSpec::Define()
 					};
 					CocoaDevice.totalMemory = @(100 * 1024 * 1024);
 
-					TSharedPtr<IBugsnagDevice> Device = FWrappedDevice::From(CocoaDevice);
+					TSharedRef<IBugsnagDevice> Device = FWrappedDevice::From(CocoaDevice);
 					TEST_EQUAL(*Device->GetJailbroken(), true);
 					TEST_EQUAL(*Device->GetId(), TEXT("uniqueId"));
 					TEST_EQUAL(*Device->GetLocale(), TEXT("en_EN"));
@@ -46,7 +46,7 @@ void FWrappedDeviceSpec::Define()
 				{
 					BugsnagDevice* CocoaDevice = [[BugsnagDevice alloc] init];
 
-					TSharedPtr<IBugsnagDevice> Device = FWrappedDevice::From(CocoaDevice);
+					TSharedRef<IBugsnagDevice> Device = FWrappedDevice::From(CocoaDevice);
 					Device->SetJailbroken(MakeShareable(new bool(true)));
 					Device->SetId(MakeShareable(new FString(TEXT("uniqueId"))));
 					Device->SetLocale(MakeShareable(new FString(TEXT("en_EN"))));

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedApp.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedApp.h
@@ -8,9 +8,14 @@
 class FWrappedApp : public IBugsnagApp
 {
 public:
-	static TSharedPtr<FWrappedApp> From(BugsnagApp* CocoaApp)
+	static TSharedRef<FWrappedApp> From(BugsnagApp* CocoaApp)
 	{
-		return MakeShareable(new FWrappedApp(CocoaApp));
+		return MakeShared<FWrappedApp>(CocoaApp);
+	}
+
+	FWrappedApp(BugsnagApp* CocoaApp)
+		: CocoaApp(CocoaApp)
+	{
 	}
 
 	// binaryArch?: string;
@@ -124,10 +129,5 @@ public:
 	}
 
 private:
-	FWrappedApp(BugsnagApp* CocoaApp)
-		: CocoaApp(CocoaApp)
-	{
-	}
-
 	BugsnagApp* CocoaApp;
 };

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedBreadcrumb.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedBreadcrumb.h
@@ -8,9 +8,14 @@
 class FWrappedBreadcrumb : public IBugsnagBreadcrumb
 {
 public:
-	static TSharedPtr<FWrappedBreadcrumb> From(BugsnagBreadcrumb* CocoaBreadcrumb)
+	static TSharedRef<FWrappedBreadcrumb> From(BugsnagBreadcrumb* CocoaBreadcrumb)
 	{
-		return MakeShareable(new FWrappedBreadcrumb(CocoaBreadcrumb));
+		return MakeShared<FWrappedBreadcrumb>(CocoaBreadcrumb);
+	}
+
+	FWrappedBreadcrumb(BugsnagBreadcrumb* CocoaBreadcrumb)
+		: CocoaBreadcrumb(CocoaBreadcrumb)
+	{
 	}
 
 	const FDateTime GetTimestamp() const override
@@ -90,10 +95,5 @@ public:
 	}
 
 private:
-	FWrappedBreadcrumb(BugsnagBreadcrumb* CocoaBreadcrumb)
-		: CocoaBreadcrumb(CocoaBreadcrumb)
-	{
-	}
-
 	BugsnagBreadcrumb* CocoaBreadcrumb;
 };

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedDevice.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedDevice.h
@@ -8,9 +8,14 @@
 class FWrappedDevice : public IBugsnagDevice
 {
 public:
-	static TSharedPtr<FWrappedDevice> From(BugsnagDevice* CocoaDevice)
+	static TSharedRef<FWrappedDevice> From(BugsnagDevice* CocoaDevice)
 	{
-		return MakeShareable(new FWrappedDevice(CocoaDevice));
+		return MakeShared<FWrappedDevice>(CocoaDevice);
+	}
+
+	FWrappedDevice(BugsnagDevice* CocoaDevice)
+		: CocoaDevice(CocoaDevice)
+	{
 	}
 
 	// cpuAbi?: string[];
@@ -170,10 +175,5 @@ public:
 	}
 
 private:
-	FWrappedDevice(BugsnagDevice* CocoaDevice)
-		: CocoaDevice(CocoaDevice)
-	{
-	}
-
 	BugsnagDevice* CocoaDevice;
 };

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedSession.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedSession.h
@@ -10,9 +10,14 @@
 class FWrappedSession : public IBugsnagSession
 {
 public:
-	static TSharedPtr<FWrappedSession> From(BugsnagSession* CocoaSession)
+	static TSharedRef<FWrappedSession> From(BugsnagSession* CocoaSession)
 	{
-		return MakeShareable(new FWrappedSession(CocoaSession));
+		return MakeShared<FWrappedSession>(CocoaSession);
+	}
+
+	FWrappedSession(BugsnagSession* CocoaSession)
+		: CocoaSession(CocoaSession)
+	{
 	}
 
 	const FString GetId() const
@@ -35,12 +40,12 @@ public:
 		CocoaSession.startedAt = NSDateFromFDateTime(StartedAt);
 	}
 
-	TSharedPtr<IBugsnagApp> GetApp()
+	TSharedRef<IBugsnagApp> GetApp()
 	{
 		return FWrappedApp::From(CocoaSession.app);
 	}
 
-	TSharedPtr<IBugsnagDevice> GetDevice()
+	TSharedRef<IBugsnagDevice> GetDevice()
 	{
 		return FWrappedDevice::From(CocoaSession.device);
 	}
@@ -61,10 +66,5 @@ public:
 	}
 
 private:
-	FWrappedSession(BugsnagSession* CocoaSession)
-		: CocoaSession(CocoaSession)
-	{
-	}
-
 	BugsnagSession* CocoaSession;
 };

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
@@ -150,7 +150,7 @@ void UBugsnagFunctionLibrary::LeaveBreadcrumb(const FString& Message, const TSha
 #endif
 }
 
-TArray<TSharedPtr<const IBugsnagBreadcrumb>> UBugsnagFunctionLibrary::GetBreadcrumbs()
+TArray<TSharedRef<const IBugsnagBreadcrumb>> UBugsnagFunctionLibrary::GetBreadcrumbs()
 {
 #if PLATFORM_IMPLEMENTS_BUGSNAG
 	return GPlatformBugsnag.GetBreadcrumbs();

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Interfaces/PlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Interfaces/PlatformBugsnag.h
@@ -43,7 +43,7 @@ public:
 
 	virtual void LeaveBreadcrumb(const FString& Message, const TSharedPtr<FJsonObject>& Metadata, EBugsnagBreadcrumbType Type) = 0;
 
-	virtual TArray<TSharedPtr<const IBugsnagBreadcrumb>> GetBreadcrumbs() = 0;
+	virtual TArray<TSharedRef<const IBugsnagBreadcrumb>> GetBreadcrumbs() = 0;
 
 	virtual void MarkLaunchCompleted() = 0;
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Specs/BugsnagConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Specs/BugsnagConfiguration.spec.cpp
@@ -51,37 +51,37 @@ void FBugsnagConfigurationSpec::Define()
 				{
 					FBugsnagConfiguration Configuration(ValidApiKey);
 
-					Configuration.AddOnBreadcrumb([](IBugsnagBreadcrumb* Breadcrumb)
+					Configuration.AddOnBreadcrumb([](TSharedRef<IBugsnagBreadcrumb> Breadcrumb)
 						{
 							UE_LOG(LogCore, Display, TEXT("Nothing to see here"));
 							return true;
 						});
 
-					Configuration.AddOnBreadcrumb([](IBugsnagBreadcrumb* Breadcrumb)
+					Configuration.AddOnBreadcrumb([](TSharedRef<IBugsnagBreadcrumb> Breadcrumb)
 						{
 							UE_LOG(LogCore, Display, TEXT("Nothing to see here"));
 							return false;
 						});
 
-					Configuration.AddOnError([](IBugsnagEvent* Error)
+					Configuration.AddOnError([](TSharedRef<IBugsnagEvent> Error)
 						{
 							UE_LOG(LogCore, Display, TEXT("Nothing to see here"));
 							return true;
 						});
 
-					Configuration.AddOnError([](IBugsnagEvent* Error)
+					Configuration.AddOnError([](TSharedRef<IBugsnagEvent> Error)
 						{
 							UE_LOG(LogCore, Display, TEXT("Nothing to see here"));
 							return false;
 						});
 
-					Configuration.AddOnSession([](IBugsnagSession* Session)
+					Configuration.AddOnSession([](TSharedRef<IBugsnagSession> Session)
 						{
 							UE_LOG(LogCore, Display, TEXT("Nothing to see here"));
 							return true;
 						});
 
-					Configuration.AddOnSession([](IBugsnagSession* Session)
+					Configuration.AddOnSession([](TSharedRef<IBugsnagSession> Session)
 						{
 							UE_LOG(LogCore, Display, TEXT("Nothing to see here"));
 							return false;

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -10,9 +10,9 @@
 
 #include "Dom/JsonObject.h"
 
-typedef TFunction<bool(IBugsnagBreadcrumb*)> FBugsnagOnBreadcrumbCallback;
-typedef TFunction<bool(IBugsnagEvent*)> FBugsnagOnErrorCallback;
-typedef TFunction<bool(IBugsnagSession*)> FBugsnagOnSessionCallback;
+typedef TFunction<bool(TSharedRef<IBugsnagBreadcrumb>)> FBugsnagOnBreadcrumbCallback;
+typedef TFunction<bool(TSharedRef<IBugsnagEvent>)> FBugsnagOnErrorCallback;
+typedef TFunction<bool(TSharedRef<IBugsnagSession>)> FBugsnagOnSessionCallback;
 
 class BUGSNAG_API FBugsnagConfiguration
 {

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
@@ -77,7 +77,7 @@ public:
 	static void LeaveBreadcrumb(const FString& Message, const TSharedPtr<FJsonObject>& Metadata,
 		EBugsnagBreadcrumbType Type = EBugsnagBreadcrumbType::Manual);
 
-	static TArray<TSharedPtr<const IBugsnagBreadcrumb>> GetBreadcrumbs();
+	static TArray<TSharedRef<const IBugsnagBreadcrumb>> GetBreadcrumbs();
 
 	// Crashes On Launch
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagSession.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagSession.h
@@ -18,9 +18,9 @@ public:
 
 	virtual void SetStartedAt(const FDateTime&) = 0;
 
-	virtual TSharedPtr<IBugsnagApp> GetApp() = 0;
+	virtual TSharedRef<IBugsnagApp> GetApp() = 0;
 
-	virtual TSharedPtr<IBugsnagDevice> GetDevice() = 0;
+	virtual TSharedRef<IBugsnagDevice> GetDevice() = 0;
 
 	virtual const FBugsnagUser GetUser() const = 0;
 

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
@@ -6,7 +6,7 @@ public:
 	void Run() override
 	{
 		// This doesn't really belong in this scenario, just checking that UBugsnagFunctionLibrary::GetBreadcrumbs() works
-		TArray<TSharedPtr<const IBugsnagBreadcrumb>> Breadcrumbs = UBugsnagFunctionLibrary::GetBreadcrumbs();
+		TArray<TSharedRef<const IBugsnagBreadcrumb>> Breadcrumbs = UBugsnagFunctionLibrary::GetBreadcrumbs();
 		assert(Breadcrumbs.Num() > 0);
 		assert(!Breadcrumbs[0].GetMessage().IsEmpty());
 


### PR DESCRIPTION
## Goal

Improve safety by using `TSharedRef<>` to represent non-nullable values, and removing the need for consumers of the API to check `IsValid()` before dereferencing.
