### PR TITLE
feat(android): implement manual session tracking

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
@@ -126,14 +126,33 @@ TSharedPtr<FBugsnagLastRunInfo> FAndroidPlatformBugsnag::GetLastRunInfo()
 
 void FAndroidPlatformBugsnag::StartSession()
 {
+	JNIEnv* Env = AndroidJavaEnv::GetJavaEnv(true);
+	if (Env && JNICache.initialized)
+	{
+		(*Env).CallStaticVoidMethod(JNICache.BugsnagClass, JNICache.BugsnagStartSession);
+		FAndroidPlatformJNI::CheckAndClearException(Env);
+	}
 }
 
 void FAndroidPlatformBugsnag::PauseSession()
 {
+	JNIEnv* Env = AndroidJavaEnv::GetJavaEnv(true);
+	if (Env && JNICache.initialized)
+	{
+		(*Env).CallStaticVoidMethod(JNICache.BugsnagClass, JNICache.BugsnagPauseSession);
+		FAndroidPlatformJNI::CheckAndClearException(Env);
+	}
 }
 
 bool FAndroidPlatformBugsnag::ResumeSession()
 {
+	JNIEnv* Env = AndroidJavaEnv::GetJavaEnv(true);
+	if (Env && JNICache.initialized)
+	{
+		jboolean result = (*Env).CallStaticBooleanMethod(JNICache.BugsnagClass, JNICache.BugsnagResumeSession);
+		FAndroidPlatformJNI::CheckAndClearException(Env);
+		return result == JNI_TRUE;
+	}
 	return false;
 }
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
@@ -82,6 +82,12 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 	cache->BugsnagLeaveBreadcrumb = (*env).GetStaticMethodID(cache->BugsnagClass, "leaveBreadcrumb",
 		"(Ljava/lang/String;Ljava/util/Map;Lcom/bugsnag/android/BreadcrumbType;)V");
 	ReturnFalseIfNullAndClearExceptions(env, cache->BugsnagLeaveBreadcrumb);
+	cache->BugsnagStartSession = (*env).GetStaticMethodID(cache->BugsnagClass, "startSession", "()V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BugsnagStartSession);
+	cache->BugsnagResumeSession = (*env).GetStaticMethodID(cache->BugsnagClass, "resumeSession", "()Z");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BugsnagResumeSession);
+	cache->BugsnagPauseSession = (*env).GetStaticMethodID(cache->BugsnagClass, "pauseSession", "()V");
+	ReturnFalseIfNullAndClearExceptions(env, cache->BugsnagPauseSession);
 
 	cache->MetadataParserParse = (*env).GetStaticMethodID(cache->MetadataParserClass, "parse", "([B)Ljava/util/Map;");
 	ReturnFalseIfNullAndClearExceptions(env, cache->MetadataParserParse);

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -30,9 +30,12 @@ typedef struct
 	jmethodID BugsnagNotifyMethod;
 	jmethodID BugsnagSetContext;
 	jmethodID BugsnagLeaveBreadcrumb;
-	jmethodID ConfigGetNotifier;
+	jmethodID BugsnagStartSession;
+	jmethodID BugsnagPauseSession;
+	jmethodID BugsnagResumeSession;
 	jmethodID ConfigAddMetadata;
 	jmethodID ConfigConstructor;
+	jmethodID ConfigGetNotifier;
 	jmethodID ConfigSetAppType;
 	jmethodID ConfigSetAppVersion;
 	jmethodID ConfigSetAutoDetectErrors;

--- a/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
+++ b/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
@@ -2,4 +2,6 @@
 static TArray<FString> ScenarioNames = {
 	TEXT("BadMemoryAccessScenario"),
 	TEXT("NotifyScenario"),
+	TEXT("PauseSessionScenario"),
+	TEXT("ResumeSessionScenario"),
 };

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/PauseSessionScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/PauseSessionScenario.cpp
@@ -1,0 +1,20 @@
+#include "Scenario.h"
+
+class PauseSessionScenario : public Scenario
+{
+public:
+	void Configure() override
+	{
+		Configuration->SetAutoTrackSessions(false);
+	}
+
+	void Run() override
+	{
+		UBugsnagFunctionLibrary::StartSession();
+		UBugsnagFunctionLibrary::PauseSession();
+		volatile int* Pointer = nullptr;
+		*Pointer = 42;
+	}
+};
+
+REGISTER_SCENARIO(PauseSessionScenario);

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/ResumeSessionScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/ResumeSessionScenario.cpp
@@ -1,0 +1,21 @@
+#include "Scenario.h"
+
+class ResumeSessionScenario : public Scenario
+{
+public:
+	void Configure() override
+	{
+		Configuration->SetAutoTrackSessions(false);
+	}
+
+	void Run() override
+	{
+		UBugsnagFunctionLibrary::StartSession();
+		UBugsnagFunctionLibrary::PauseSession();
+		UBugsnagFunctionLibrary::ResumeSession();
+		volatile int* Pointer = nullptr;
+		*Pointer = 42;
+	}
+};
+
+REGISTER_SCENARIO(ResumeSessionScenario);

--- a/features/sessions.feature
+++ b/features/sessions.feature
@@ -1,0 +1,20 @@
+Feature: Session tracking
+
+  Scenario: Starting and pausing a session before a crash
+    When I run "PauseSessionScenario"
+    Then the app is not running
+
+    When I relaunch the app
+    And I configure Bugsnag for "PauseSessionScenario"
+    And I wait to receive an error
+    Then the event "session" is null
+
+  @skip_ios
+  Scenario: Resuming a session before a crash
+    When I run "ResumeSessionScenario"
+    Then the app is not running
+
+    When I relaunch the app
+    And I configure Bugsnag for "ResumeSessionScenario"
+    And I wait to receive an error
+    Then the event "session.id" is not null

--- a/features/support/scenario_names.rb
+++ b/features/support/scenario_names.rb
@@ -2,4 +2,6 @@
 $scenario_names = [
   'BadMemoryAccessScenario',
   'NotifyScenario',
+  'PauseSessionScenario',
+  'ResumeSessionScenario',
 ]


### PR DESCRIPTION
## Goal

Support manual session tracking

## Testing

Tested manually and with new automated tests - restricted to Android only because they seem to [consistently fail on iOS](https://buildkite.com/bugsnag/bugsnag-unreal/builds/157#bcaebdde-9c22-43a8-8c6c-b09941a72080/261-268)?