### PR TITLE
refactor(platform): define notify aliases in header

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         upload:
+          - features/fixtures/mobile/Binaries/IOS/TestFixture-IOS-Shipping.dSYM
           - features/fixtures/mobile/Binaries/IOS/TestFixture-IOS-Shipping.ipa
     command: make features/fixtures/mobile/Binaries/IOS/TestFixture-IOS-Shipping.ipa
     timeout_in_minutes: 40
@@ -120,7 +121,7 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/mobile/Binaries/IOS/TestFixture-IOS-Shipping.ipa"]
+        download: ["features/fixtures/mobile/Binaries/IOS/TestFixture-IOS-Shipping.ipa","features/fixtures/mobile/Binaries/IOS/TestFixture-IOS-Shipping.dSYM"]
         upload: ["maze_output/failed/**/*"]
       docker-compose#v3.3.0:
         run: cocoa-maze-runner

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
@@ -26,18 +26,6 @@ void FAndroidPlatformBugsnag::Start(const TSharedPtr<FBugsnagConfiguration>& Con
 	}
 }
 
-void FAndroidPlatformBugsnag::Notify(const FString& ErrorClass, const FString& Message)
-{
-}
-
-void FAndroidPlatformBugsnag::Notify(const FString& ErrorClass, const FString& Message, const FBugsnagOnErrorCallback& Callback)
-{
-}
-
-void FAndroidPlatformBugsnag::Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace)
-{
-}
-
 void FAndroidPlatformBugsnag::Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
 	const FBugsnagOnErrorCallback& Callback)
 {

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
@@ -7,12 +7,6 @@ class FAndroidPlatformBugsnag : public IPlatformBugsnag
 public:
 	void Start(const TSharedPtr<FBugsnagConfiguration>& Configuration) override;
 
-	void Notify(const FString& ErrorClass, const FString& Message) override;
-
-	void Notify(const FString& ErrorClass, const FString& Message, const FBugsnagOnErrorCallback& Callback) override;
-
-	void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace) override;
-
 	void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
 		const FBugsnagOnErrorCallback& Callback) override;
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.h
@@ -7,12 +7,6 @@ class FApplePlatformBugsnag : public IPlatformBugsnag
 public:
 	void Start(const TSharedPtr<FBugsnagConfiguration>& Configuration) override;
 
-	void Notify(const FString& ErrorClass, const FString& Message) override;
-
-	void Notify(const FString& ErrorClass, const FString& Message, const FBugsnagOnErrorCallback& Callback) override;
-
-	void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace) override;
-
 	void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
 		const FBugsnagOnErrorCallback& Callback) override;
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Interfaces/PlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Interfaces/PlatformBugsnag.h
@@ -12,12 +12,6 @@ class IPlatformBugsnag
 public:
 	virtual void Start(const TSharedPtr<FBugsnagConfiguration>& Configuration) = 0;
 
-	virtual void Notify(const FString& ErrorClass, const FString& Message) = 0;
-
-	virtual void Notify(const FString& ErrorClass, const FString& Message, const FBugsnagOnErrorCallback& Callback) = 0;
-
-	virtual void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace) = 0;
-
 	virtual void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
 		const FBugsnagOnErrorCallback& Callback) = 0;
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
@@ -27,18 +27,28 @@ public:
 	// Notify
 
 	// Report an error to Bugsnag.
+	FORCEINLINE
 	UFUNCTION(BlueprintCallable, Category = "Bugsnag")
-	static void Notify(const FString& ErrorClass, const FString& Message);
+	static void Notify(const FString& ErrorClass, const FString& Message)
+	{
+		Notify(ErrorClass, Message, CaptureStackTrace(), nullptr);
+	};
 
-	static void Notify(const FString& ErrorClass, const FString& Message, const FBugsnagOnErrorCallback& Callback);
+	FORCEINLINE static void Notify(const FString& ErrorClass, const FString& Message, const FBugsnagOnErrorCallback& Callback)
+	{
+		Notify(ErrorClass, Message, CaptureStackTrace(), Callback);
+	};
 
-	static void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace);
+	static void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace)
+	{
+		Notify(ErrorClass, Message, StackTrace, nullptr);
+	};
 
 	static void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
 		const FBugsnagOnErrorCallback& Callback);
 
 	// Returns the stack trace of the calling thread.
-	static TArray<uint64> CaptureStackTrace();
+	FORCENOINLINE static TArray<uint64> CaptureStackTrace();
 
 	// Context
 

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -41,3 +41,4 @@ Feature: Reporting handled errors
     And the event has a "state" breadcrumb named "Bugsnag loaded"
     And the exception "errorClass" equals "Internal Error"
     And the exception "message" equals "Does not compute"
+    And the method of stack frame 0 is equivalent to "NotifyScenario::Run()"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -35,3 +35,20 @@ def is_platform? name
   # > is_platform? 'ios'
   current_platform.casecmp(name.to_s) == 0
 end
+
+def platform_artifact_dir
+  if is_platform? 'iOS'
+    'IOS' # why did they do this to us lol
+  else
+    current_platform.capitalize
+  end
+end
+
+def artifact_path
+  if Maze.config.farm == :local
+    File.join(File.dirname(__FILE__), '..', 'fixtures', 'mobile', 'Binaries', platform_artifact_dir)
+  else
+    '/app/build'
+  end
+end
+

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -18,3 +18,4 @@ Feature: Unhandled errors
     And the event "metaData.pastries.macaron" equals 3
     And the event "metaData.counters.forty" equals "40"
     And the event "metaData.counters.thirty-five" equals "35"
+    And the method of stack frame 0 is equivalent to "BadMemoryAccessScenario::Run()"


### PR DESCRIPTION
Realized while writing the implementation for Android that with the addition of `CaptureStackTrace()`, we could simplify the platform variants to just one. What do you think?

## Testing

* Used the automated tests to verify the behavior