### PR TITLE
feat(android): support sending handled errors

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
@@ -79,7 +79,7 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 		"(Ljava/lang/String;)V");
 	ReturnFalseIfNullAndClearExceptions(env, cache->BugsnagSetContext);
 	cache->BugsnagNotifyMethod = (*env).GetStaticMethodID(cache->InterfaceClass, "notify",
-		"([B[BLcom/bugsnag/android/Severity;[Ljava/lang/StackTraceElement;)V");
+		"(Ljava/lang/String;Ljava/lang/String;Lcom/bugsnag/android/Severity;[Ljava/lang/StackTraceElement;)V");
 	ReturnFalseIfNullAndClearExceptions(env, cache->BugsnagNotifyMethod);
 	cache->BugsnagLeaveBreadcrumb = (*env).GetStaticMethodID(cache->BugsnagClass, "leaveBreadcrumb",
 		"(Ljava/lang/String;Ljava/util/Map;Lcom/bugsnag/android/BreadcrumbType;)V");
@@ -383,6 +383,31 @@ jobject FAndroidPlatformJNI::ParseInteger(JNIEnv* Env, const JNIReferenceCache* 
 		return nullptr;
 	}
 	return jValue;
+}
+
+jobject FAndroidPlatformJNI::ParseSeverity(JNIEnv* Env, const JNIReferenceCache* Cache, const EBugsnagSeverity Value)
+{
+	jfieldID FieldName;
+	switch (Value)
+	{
+	case EBugsnagSeverity::Info:
+		FieldName = Cache->SeverityFieldInfo;
+		break;
+	case EBugsnagSeverity::Warning:
+		FieldName = Cache->SeverityFieldWarning;
+		break;
+	case EBugsnagSeverity::Error:
+		FieldName = Cache->SeverityFieldError;
+		break;
+	default:
+		return nullptr;
+	}
+	jobject jSeverity = (*Env).GetStaticObjectField(Cache->SeverityClass, FieldName);
+	if (FAndroidPlatformJNI::CheckAndClearException(Env))
+	{
+		return nullptr;
+	}
+	return jSeverity;
 }
 
 jobject FAndroidPlatformJNI::ParseThreadSendPolicy(JNIEnv* Env, const JNIReferenceCache* Cache, const EBugsnagSendThreadsPolicy Policy)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -3,6 +3,7 @@
 #include <jni.h>
 
 #include "BugsnagBreadcrumb.h"
+#include "BugsnagEvent.h"
 #include "BugsnagSettings.h"
 
 typedef struct
@@ -167,6 +168,17 @@ public:
    * @return A Java object reference or null on failure
    */
 	static jobject ParseBreadcrumbTypeSet(JNIEnv* Env, const JNIReferenceCache* Cache, const FBugsnagEnabledBreadcrumbTypes Value);
+
+	/**
+   * Convert a value into a Java Severity
+   *
+   * @param Env   A JNI environment for the current thread
+   * @param Cache A populated reference cache
+   * @param Value The severity value to convert
+   *
+   * @return A Java object reference or null on failure
+   */
+	static jobject ParseSeverity(JNIEnv* Env, const JNIReferenceCache* Cache, const EBugsnagSeverity Value);
 
 	/**
    * Convert a value into a Java ThreadSendPolicy

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/Shorthand.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/Shorthand.h
@@ -31,3 +31,9 @@
 		env->ExceptionClear();      \
 		return false;               \
 	}
+
+#define ReturnVoidIf(condition) \
+	if (condition)              \
+	{                           \
+		return;                 \
+	}

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -1,6 +1,5 @@
 Feature: Reporting handled errors
 
-  @skip_android
   Scenario: NotifyScenario
     When I run "NotifyScenario"
     And I wait to receive an error
@@ -15,9 +14,11 @@ Feature: Reporting handled errors
     And the event "app.id" equals "com.bugsnag.TestFixture"
     And the event "app.inForeground" is true
     And the event "app.isLaunching" is true
-    And the event "app.releaseStage" equals "production"
-    And the event "app.type" equals "iOS"
-    And the event "app.version" equals "1.0"
+    # TODO: PLAT-7427 - investigate android release stage detection improvements
+    And on iOS, the event "app.releaseStage" equals "production"
+    And the error payload field "events.0.app.type" equals the platform-dependent string:
+      | android | android |
+      | ios     | iOS     |
     And the event "app.version" equals "1.0"
     And the event "device.freeDisk" is not null
     And the event "device.freeMemory" is not null
@@ -26,9 +27,11 @@ Feature: Reporting handled errors
     And the event "device.locale" is not null
     And the event "device.manufacturer" is not null
     And the event "device.model" is not null
-    And the event "device.modelNumber" is not null
+    And on iOS, the event "device.modelNumber" is not null
     And the event "device.orientation" matches "(face(down|up)|landscape(left|right)|portrait(upsidedown)?)"
-    And the event "device.osName" matches "(android|iOS)"
+    And the error payload field "events.0.device.osName" equals the platform-dependent string:
+      | android | android |
+      | ios     | iOS     |
     And the event "device.osVersion" is not null
     And the event "device.runtimeVersions" is not null
     And the event "device.time" is not null
@@ -36,9 +39,14 @@ Feature: Reporting handled errors
     And the event "metaData.device.batteryLevel" is not null
     And the event "metaData.device.charging" is not null
     And the event "severity" equals "warning"
-    And the event "severityReason.type" equals "handledError"
+    And the error payload field "events.0.severityReason.type" equals the platform-dependent string:
+      | android | handledException |
+      | ios     | handledError     |
     And the event "unhandled" is false
     And the event has a "state" breadcrumb named "Bugsnag loaded"
     And the exception "errorClass" equals "Internal Error"
     And the exception "message" equals "Does not compute"
     And the method of stack frame 0 is equivalent to "NotifyScenario::Run()"
+    And the error payload field "events.0.exceptions.0.type" equals the platform-dependent string:
+      | android | c     |
+      | ios     | cocoa |

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -9,15 +9,6 @@ Before do |_scenario|
   sleep 5 if is_platform? 'Android'
 end
 
-# TODO: Remove one of not/skip tags once the dust settles on changes
-Before('@not_android') do |_scenario|
-  skip_this_scenario("Not compatible with Android") if is_platform? 'Android'
-end
-
-Before('@not_ios') do |_scenario|
-  skip_this_scenario("Not compatible with iOS") if is_platform? 'iOS'
-end
-
 Before('@skip_android') do |_scenario|
   skip_this_scenario("Not compatible with Android") if is_platform? 'Android'
 end


### PR DESCRIPTION
## Goal

Implement `Notify()` (aside from callbacks).

As an aside, the Event class is missing Severity? Added an enum for it in the meantime.

## Testing

Updated the existing handled errors test to support both platforms.