### PR TITLE
Fix crash when invoking callbacks

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
@@ -137,14 +137,14 @@ bool FAndroidPlatformBugsnag::ResumeSession()
 	return false;
 }
 
-void FAndroidPlatformBugsnag::AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback)
+void FAndroidPlatformBugsnag::AddOnBreadcrumb(FBugsnagOnBreadcrumbCallback Callback)
 {
 }
 
-void FAndroidPlatformBugsnag::AddOnSendError(const FBugsnagOnErrorCallback& Callback)
+void FAndroidPlatformBugsnag::AddOnSendError(FBugsnagOnErrorCallback Callback)
 {
 }
 
-void FAndroidPlatformBugsnag::AddOnSession(const FBugsnagOnSessionCallback& Callback)
+void FAndroidPlatformBugsnag::AddOnSession(FBugsnagOnSessionCallback Callback)
 {
 }

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
@@ -44,11 +44,11 @@ public:
 
 	bool ResumeSession() override;
 
-	void AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback) override;
+	void AddOnBreadcrumb(FBugsnagOnBreadcrumbCallback Callback) override;
 
-	void AddOnSendError(const FBugsnagOnErrorCallback& Callback) override;
+	void AddOnSendError(FBugsnagOnErrorCallback Callback) override;
 
-	void AddOnSession(const FBugsnagOnSessionCallback& Callback) override;
+	void AddOnSession(FBugsnagOnSessionCallback Callback) override;
 };
 
 DECLARE_PLATFORM_BUGSNAG(FAndroidPlatformBugsnag)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
@@ -163,21 +163,21 @@ bool FApplePlatformBugsnag::ResumeSession()
 	return [Bugsnag resumeSession];
 }
 
-void FApplePlatformBugsnag::AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback)
+void FApplePlatformBugsnag::AddOnBreadcrumb(FBugsnagOnBreadcrumbCallback Callback)
 {
-	[Bugsnag removeOnBreadcrumbBlock:^BOOL(BugsnagBreadcrumb* _Nonnull Breadcrumb) {
+	[Bugsnag addOnBreadcrumbBlock:^BOOL(BugsnagBreadcrumb* _Nonnull Breadcrumb) {
 		return Callback(FWrappedBreadcrumb::From(Breadcrumb));
 	}];
 }
 
-void FApplePlatformBugsnag::AddOnSendError(const FBugsnagOnErrorCallback& Callback)
+void FApplePlatformBugsnag::AddOnSendError(FBugsnagOnErrorCallback Callback)
 {
 	[Bugsnag.configuration addOnSendErrorBlock:^BOOL(BugsnagEvent* _Nonnull Event) {
 		return Callback(FWrappedEvent::From(Event));
 	}];
 }
 
-void FApplePlatformBugsnag::AddOnSession(const FBugsnagOnSessionCallback& Callback)
+void FApplePlatformBugsnag::AddOnSession(FBugsnagOnSessionCallback Callback)
 {
 	[Bugsnag addOnSessionBlock:^BOOL(BugsnagSession* _Nonnull Session) {
 		return Callback(FWrappedSession::From(Session));

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.h
@@ -44,11 +44,11 @@ public:
 
 	bool ResumeSession() override;
 
-	void AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback) override;
+	void AddOnBreadcrumb(FBugsnagOnBreadcrumbCallback Callback) override;
 
-	void AddOnSendError(const FBugsnagOnErrorCallback& Callback) override;
+	void AddOnSendError(FBugsnagOnErrorCallback Callback) override;
 
-	void AddOnSession(const FBugsnagOnSessionCallback& Callback) override;
+	void AddOnSession(FBugsnagOnSessionCallback Callback) override;
 };
 
 DECLARE_PLATFORM_BUGSNAG(FApplePlatformBugsnag)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
@@ -154,21 +154,21 @@ BugsnagConfiguration* FApplePlatformConfiguration::Configuration(const TSharedPt
 		}
 	}
 
-	for (auto& Callback : Configuration->GetOnBreadcrumbCallbacks())
+	for (auto Callback : Configuration->GetOnBreadcrumbCallbacks())
 	{
 		[CocoaConfig addOnBreadcrumbBlock:^BOOL(BugsnagBreadcrumb* _Nonnull Breadcrumb) {
 			return Callback(FWrappedBreadcrumb::From(Breadcrumb));
 		}];
 	}
 
-	for (auto& Callback : Configuration->GetOnSendErrorCallbacks())
+	for (auto Callback : Configuration->GetOnSendErrorCallbacks())
 	{
 		[CocoaConfig addOnSendErrorBlock:^BOOL(BugsnagEvent* _Nonnull Event) {
 			return Callback(FWrappedEvent::From(Event));
 		}];
 	}
 
-	for (auto& Callback : Configuration->GetOnSessionCallbacks())
+	for (auto Callback : Configuration->GetOnSessionCallbacks())
 	{
 		[CocoaConfig addOnSessionBlock:^BOOL(BugsnagSession* _Nonnull Session) {
 			return Callback(FWrappedSession::From(Session));

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
@@ -187,21 +187,21 @@ bool UBugsnagFunctionLibrary::ResumeSession()
 #endif
 }
 
-void UBugsnagFunctionLibrary::AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback)
+void UBugsnagFunctionLibrary::AddOnBreadcrumb(FBugsnagOnBreadcrumbCallback Callback)
 {
 #if PLATFORM_IMPLEMENTS_BUGSNAG
 	GPlatformBugsnag.AddOnBreadcrumb(Callback);
 #endif
 }
 
-void UBugsnagFunctionLibrary::AddOnSendError(const FBugsnagOnErrorCallback& Callback)
+void UBugsnagFunctionLibrary::AddOnSendError(FBugsnagOnErrorCallback Callback)
 {
 #if PLATFORM_IMPLEMENTS_BUGSNAG
 	GPlatformBugsnag.AddOnSendError(Callback);
 #endif
 }
 
-void UBugsnagFunctionLibrary::AddOnSession(const FBugsnagOnSessionCallback& Callback)
+void UBugsnagFunctionLibrary::AddOnSession(FBugsnagOnSessionCallback Callback)
 {
 #if PLATFORM_IMPLEMENTS_BUGSNAG
 	GPlatformBugsnag.AddOnSession(Callback);

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Interfaces/PlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Interfaces/PlatformBugsnag.h
@@ -49,11 +49,11 @@ public:
 
 	virtual bool ResumeSession() = 0;
 
-	virtual void AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback) = 0;
+	virtual void AddOnBreadcrumb(FBugsnagOnBreadcrumbCallback Callback) = 0;
 
-	virtual void AddOnSendError(const FBugsnagOnErrorCallback& Callback) = 0;
+	virtual void AddOnSendError(FBugsnagOnErrorCallback Callback) = 0;
 
-	virtual void AddOnSession(const FBugsnagOnSessionCallback& Callback) = 0;
+	virtual void AddOnSession(FBugsnagOnSessionCallback Callback) = 0;
 };
 
 #define DECLARE_PLATFORM_BUGSNAG(CLASS) \

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -204,15 +204,15 @@ public:
 
 	// Callbacks
 
-	void AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback) { OnBreadcrumbCallbacks.Add(Callback); }
+	void AddOnBreadcrumb(FBugsnagOnBreadcrumbCallback Callback) { OnBreadcrumbCallbacks.Add(Callback); }
 
 	// Android only, and only for handled errors.
-	void AddOnError(const FBugsnagOnErrorCallback& Callback) { OnErrorCallbacks.Add(Callback); }
+	void AddOnError(FBugsnagOnErrorCallback Callback) { OnErrorCallbacks.Add(Callback); }
 
 	// iOS only, may be called long after the crash occurred.
-	void AddOnSendError(const FBugsnagOnErrorCallback& Callback) { OnSendErrorCallbacks.Add(Callback); }
+	void AddOnSendError(FBugsnagOnErrorCallback Callback) { OnSendErrorCallbacks.Add(Callback); }
 
-	void AddOnSession(const FBugsnagOnSessionCallback& Callback) { OnSessionCallbacks.Add(Callback); }
+	void AddOnSession(FBugsnagOnSessionCallback Callback) { OnSessionCallbacks.Add(Callback); }
 
 private:
 	FBugsnagConfiguration(const UBugsnagSettings& Settings);

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
@@ -114,9 +114,9 @@ public:
 
 	// Filtering
 
-	void AddOnBreadcrumb(const FBugsnagOnBreadcrumbCallback& Callback);
+	static void AddOnBreadcrumb(FBugsnagOnBreadcrumbCallback Callback);
 
-	void AddOnSendError(const FBugsnagOnErrorCallback& Callback);
+	static void AddOnSendError(FBugsnagOnErrorCallback Callback);
 
-	void AddOnSession(const FBugsnagOnSessionCallback& Callback);
+	static void AddOnSession(FBugsnagOnSessionCallback Callback);
 };

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
@@ -19,10 +19,40 @@ public:
 		Configuration->AddMetadata("pastries", Section1);
 		Configuration->AddMetadata("counters", Section2);
 		Configuration->AddMetadata("counters", "thirty-five", MakeShareable(Value));
+
+		Configuration->AddOnBreadcrumb([](TSharedRef<IBugsnagBreadcrumb> Breadcrumb)
+			{
+				return true;
+			});
+
+		Configuration->AddOnSendError([](TSharedRef<IBugsnagEvent> Event)
+			{
+				return true;
+			});
+
+		Configuration->AddOnSession([](TSharedRef<IBugsnagSession> Session)
+			{
+				return true;
+			});
 	}
 
 	void Run() override
 	{
+		UBugsnagFunctionLibrary::AddOnBreadcrumb([](TSharedRef<IBugsnagBreadcrumb> Breadcrumb)
+			{
+				return true;
+			});
+
+		UBugsnagFunctionLibrary::AddOnSendError([](TSharedRef<IBugsnagEvent> Event)
+			{
+				return true;
+			});
+
+		UBugsnagFunctionLibrary::AddOnSession([](TSharedRef<IBugsnagSession> Session)
+			{
+				return true;
+			});
+
 		UBugsnagFunctionLibrary::LeaveBreadcrumb(TEXT("About to read from a bad memory address"));
 		FPlatformProcess::Sleep(0.5f); // Leave time for async breadcrumb I/O
 

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/NotifyScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/NotifyScenario.cpp
@@ -3,8 +3,41 @@
 class NotifyScenario : public Scenario
 {
 public:
+	void Configure() override
+	{
+		Configuration->AddOnBreadcrumb([](TSharedRef<IBugsnagBreadcrumb> Breadcrumb)
+			{
+				return true;
+			});
+
+		Configuration->AddOnSendError([](TSharedRef<IBugsnagEvent> Event)
+			{
+				return true;
+			});
+
+		Configuration->AddOnSession([](TSharedRef<IBugsnagSession> Session)
+			{
+				return true;
+			});
+	}
+
 	void Run() override
 	{
+		UBugsnagFunctionLibrary::AddOnBreadcrumb([](TSharedRef<IBugsnagBreadcrumb> Breadcrumb)
+			{
+				return true;
+			});
+
+		UBugsnagFunctionLibrary::AddOnSendError([](TSharedRef<IBugsnagEvent> Event)
+			{
+				return true;
+			});
+
+		UBugsnagFunctionLibrary::AddOnSession([](TSharedRef<IBugsnagSession> Session)
+			{
+				return true;
+			});
+
 		UBugsnagFunctionLibrary::SetContext("pause menu");
 
 		UBugsnagFunctionLibrary::Notify(TEXT("Internal Error"), TEXT("Does not compute"));


### PR DESCRIPTION
While working on support for (and testing of) metadata a crash was encountered when OnSendError (or other callbacks) are invoked.

Investigation revealed the crashes were due to taking `TFunction&` by reference - which works fine when called synchronously - when we actually want to take a copy of the `TFunction` to make it safe to invoke at a later point in time when the original stack has been destroyed.

E2E tests were amended to verify that no crashes occur in the callbacks.