### PR TITLE
[PLAT-7336] Implement GetLastRunInfo() and MarkLaunchCompleted()

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
@@ -115,11 +115,20 @@ TArray<TSharedRef<const IBugsnagBreadcrumb>> FApplePlatformBugsnag::GetBreadcrum
 
 void FApplePlatformBugsnag::MarkLaunchCompleted()
 {
+	[Bugsnag markLaunchCompleted];
 }
 
 TSharedPtr<FBugsnagLastRunInfo> FApplePlatformBugsnag::GetLastRunInfo()
 {
-	return nullptr;
+	BugsnagLastRunInfo* LastRunInfo = Bugsnag.lastRunInfo;
+	if (!LastRunInfo)
+	{
+		return nullptr;
+	}
+	return MakeShareable(new FBugsnagLastRunInfo(
+		LastRunInfo.consecutiveLaunchCrashes,
+		LastRunInfo.crashed,
+		LastRunInfo.crashedDuringLaunch));
 }
 
 void FApplePlatformBugsnag::StartSession()

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
@@ -27,6 +27,17 @@ public:
 		Configuration->AddOnSendError([](TSharedRef<IBugsnagEvent> Event)
 			{
 				Event->AddMetadata(TEXT("custom"), TEXT("configOnSendError"), MakeShareable(new FJsonValueString(TEXT("hello"))));
+
+				TSharedPtr<FBugsnagLastRunInfo> LastRunInfo = UBugsnagFunctionLibrary::GetLastRunInfo();
+				if (LastRunInfo.IsValid())
+				{
+					TSharedPtr<FJsonObject> Metadata = MakeShared<FJsonObject>();
+					Metadata->SetNumberField(TEXT("consecutiveLaunchCrashes"), LastRunInfo->GetConsecutiveLaunchCrashes());
+					Metadata->SetBoolField(TEXT("crashed"), LastRunInfo->GetCrashed());
+					Metadata->SetBoolField(TEXT("crashedDuringLaunch"), LastRunInfo->GetCrashedDuringLaunch());
+					Event->AddMetadata(TEXT("lastRunInfo"), Metadata);
+				}
+
 				return true;
 			});
 

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -15,12 +15,18 @@ Feature: Unhandled errors
     And on Android, the event "context" equals "overhead view"
     And the event has a "state" breadcrumb named "Bugsnag loaded"
     And the event has a "manual" breadcrumb named "About to read from a bad memory address"
+    And the event "app.isLaunching" is true
     And the event "metaData.pastries.cronut" is false
     And the event "metaData.pastries.macaron" equals 3
     And the event "metaData.counters.forty" equals "40"
     And the event "metaData.counters.thirty-five" equals "35"
+    # TODO: pending on Android (PLAT-7364)
     And on iOS, the event "metaData.custom.configOnSendError" equals "hello"
     And on iOS, the event "metaData.custom.someValue" equals "foobar"
+    # TODO: pending on Android (PLAT-7364, PLAT-7367, PLAT-7369)
+    And on iOS, the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 1
+    And on iOS, the event "metaData.lastRunInfo.crashed" is true
+    And on iOS, the event "metaData.lastRunInfo.crashedDuringLaunch" is true
     And the method of stack frame 0 is equivalent to "BadMemoryAccessScenario::Run()"
     And the error payload field "events.0.exceptions.0.errorClass" equals the platform-dependent string:
       | android | SIGSEGV |


### PR DESCRIPTION
## Goal

Implement `GetLastRunInfo()` and `MarkLaunchCompleted()`

## Changeset

Implements these methods on `FApplePlatformBugsnag` and verifies returned last run info through an E2E scenario.