### PR TITLE
Support get/set user on Android

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidSession.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidSession.h
@@ -73,26 +73,7 @@ public:
 	const FBugsnagUser GetUser() const
 	{
 		jobject jUser = (*Env).CallObjectMethod(Session, Cache->SessionGetUser);
-		if (FAndroidPlatformJNI::CheckAndClearException(Env))
-		{
-			return FBugsnagUser(
-				MakeShareable(new FString("")),
-				MakeShareable(new FString("")),
-				MakeShareable(new FString("")));
-		}
-		jobject jId = (*Env).CallObjectMethod(jUser, Cache->UserGetId);
-		FAndroidPlatformJNI::CheckAndClearException(Env);
-		FString Id = FAndroidPlatformJNI::ParseJavaString(Env, Cache, jId);
-		jobject jName = (*Env).CallObjectMethod(jUser, Cache->UserGetName);
-		FAndroidPlatformJNI::CheckAndClearException(Env);
-		FString Name = FAndroidPlatformJNI::ParseJavaString(Env, Cache, jName);
-		jobject jEmail = (*Env).CallObjectMethod(jUser, Cache->UserGetEmail);
-		FAndroidPlatformJNI::CheckAndClearException(Env);
-		FString Email = FAndroidPlatformJNI::ParseJavaString(Env, Cache, jEmail);
-		return FBugsnagUser(
-			MakeShared<FString>(Id),
-			MakeShared<FString>(Email),
-			MakeShared<FString>(Name));
+		return FAndroidPlatformJNI::ParseJavaUser(Env, Cache, jUser);
 	}
 
 	void SetUser(const TSharedPtr<FString>& Id, const TSharedPtr<FString>& Email, const TSharedPtr<FString>& Name)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -62,6 +62,7 @@ typedef struct
 	jmethodID BreadcrumbSetMessage;
 	jmethodID BreadcrumbSetMetadata;
 	jmethodID BreadcrumbSetType;
+	jmethodID BugsnagGetUser;
 	jmethodID BugsnagStartMethod;
 	jmethodID BugsnagNotifyMethod;
 	jmethodID BugsnagSetContext;
@@ -69,6 +70,7 @@ typedef struct
 	jmethodID BugsnagStartSession;
 	jmethodID BugsnagPauseSession;
 	jmethodID BugsnagResumeSession;
+	jmethodID BugsnagSetUser;
 	jmethodID BugsnagUnrealPluginConstructor;
 	jmethodID ConfigAddMetadata;
 	jmethodID ConfigAddPlugin;
@@ -306,6 +308,17 @@ public:
      * @return A string object, empty in the event of failure
      */
 	static FString ParseJavaString(JNIEnv* Env, const JNIReferenceCache* Cache, jobject Value);
+
+	/**
+     * Convert a Bugsnag Java User into a FBugsnagUser
+     *
+     * @param Env   A JNI environment for the current thread
+     * @param Cache A populated reference cache
+     * @param Value A jobject representing a Java User
+     *
+     * @return A user object, with empty fields in the event of an error
+     */
+	static FBugsnagUser ParseJavaUser(JNIEnv* Env, const JNIReferenceCache* Cache, jobject Value);
 
 	/**
    * Convert a Java map into a JSON object

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
@@ -72,6 +72,8 @@ public:
 
 		UBugsnagFunctionLibrary::SetContext("overhead view");
 
+		UBugsnagFunctionLibrary::SetUser("5402", "usr@example.com", "");
+
 		volatile int* Pointer = nullptr;
 		*Pointer = 42;
 	}

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/NotifyScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/NotifyScenario.cpp
@@ -55,6 +55,8 @@ public:
 
 		UBugsnagFunctionLibrary::AddMetadata(TEXT("custom"), TEXT("someValue"), MakeShareable(new FJsonValueString(TEXT("foobar"))));
 
+		UBugsnagFunctionLibrary::SetUser("1118", "emilie@example.com", "Emilie");
+
 		UBugsnagFunctionLibrary::Notify(TEXT("Internal Error"), TEXT("Does not compute"), [](TSharedRef<IBugsnagEvent> Event)
 			{
 				Event->AddMetadata(TEXT("custom"), TEXT("notify"), MakeShareable(new FJsonValueString(TEXT("testing"))));

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -42,6 +42,10 @@ Feature: Reporting handled errors
     And the event "metaData.pastries.macaron" equals 3
     And the event "metaData.counters.forty" equals "40"
     And the event "metaData.counters.thirty-five" equals "35"
+    # TODO: pending on iOS
+    And on Android, the event "user.id" equals "1118"
+    And on Android, the event "user.email" equals "emilie@example.com"
+    And on Android, the event "user.name" equals "Emilie"
     # TODO: pending on Android (PLAT-7364)
     And on iOS, the event "metaData.custom.configOnSendError" equals "hello"
     And on iOS, the event "metaData.custom.someValue" equals "foobar"

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -20,6 +20,10 @@ Feature: Unhandled errors
     And the event "metaData.pastries.macaron" equals 3
     And the event "metaData.counters.forty" equals "40"
     And the event "metaData.counters.thirty-five" equals "35"
+    # TODO: pending on iOS
+    And on Android, the event "user.id" equals "5402"
+    And on Android, the event "user.email" equals "usr@example.com"
+    And on Android, the event "user.name" is null
     # TODO: pending on Android (PLAT-7364)
     And on iOS, the event "metaData.custom.configOnSendError" equals "hello"
     And on iOS, the event "metaData.custom.someValue" equals "foobar"


### PR DESCRIPTION
Implement get and set user for the Android platform.

## Changeset

* Small refactor to make creating a FBugsnagUser from a Java User object reusable

## Testing

* Updated handled and unhandled tests to set user info