### PR TITLE
Set release stage to "production" in Android shipping builds

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
+++ b/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
@@ -8,6 +8,8 @@
             section="/Script/Bugsnag.BugsnagSettings"
             property="ApiKey"
             default=""/>
+        <setBoolEquals result="bIsShipping" arg1="$S(Configuration)" arg2="Shipping"/>
+        <setBoolOr result="bShouldUploadBuildMetadata" arg1="$B(bIsShipping)" arg2="$B(Distribution)"/>
     </init>
 
     <androidManifestUpdates>
@@ -49,6 +51,17 @@
         <insert>
             apply plugin: "com.bugsnag.android.gradle"
         </insert>
+        <if condition="bShouldUploadBuildMetadata">
+            <true>
+                <insert>
+bugsnag {
+    uploadJvmMappings = true
+    uploadNdkMappings = true
+    reportBuilds = true
+}
+                </insert>
+            </true>
+        </if>
     </buildGradleAdditions>
 
     <!-- optional additions to the GameActivity imports in GameActivity.java -->

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
@@ -95,6 +95,13 @@ jobject FAndroidPlatformConfiguration::Parse(JNIEnv* Env,
 	{
 		jniCallWithString(Env, jConfig, Cache->ConfigSetReleaseStage, Config->GetReleaseStage());
 	}
+	else
+	{
+		// explicitly set production for shipping builds, otherwise use bugsnag-android default detection
+#if UE_BUILD_SHIPPING
+		jniCallWithString(Env, jConfig, Cache->ConfigSetReleaseStage, MakeShareable(new FString("production")));
+#endif
+	}
 	jniCallWithBool(Env, jConfig, Cache->ConfigSetSendLaunchCrashesSynchronously, Config->GetSendLaunchCrashesSynchronously());
 	jobject jThreadPolicy = FAndroidPlatformJNI::ParseThreadSendPolicy(Env, Cache, Config->GetSendThreads());
 	ReturnNullOnFail(jThreadPolicy);

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -14,8 +14,7 @@ Feature: Reporting handled errors
     And the event "app.id" equals "com.bugsnag.TestFixture"
     And the event "app.inForeground" is true
     And the event "app.isLaunching" is true
-    # TODO: PLAT-7427 - investigate android release stage detection improvements
-    And on iOS, the event "app.releaseStage" equals "production"
+    And the event "app.releaseStage" equals "production"
     And the event "app.type" equals the platform-dependent string:
       | android | android |
       | ios     | iOS     |


### PR DESCRIPTION

## Goal

Fix automatic release stage detection on Android. Shipping builds include the "debuggable" flag in app info, which is used to detect a development release stage in regular Android builds. Reused similar logic to enable automatic symbol file upload when an API key is configured in settings.

## Changeset

* Conditionally set the release stage if none was provided - we could move this logic "upstream" in the future if needed for platforms where we don't have an underlying bugsnag lib.

## Testing

* Removed one (1) TODO in a test!