### PR TITLE
Support mark launch completed on Android

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
@@ -197,6 +197,10 @@ TArray<TSharedRef<const class IBugsnagBreadcrumb>> FAndroidPlatformBugsnag::GetB
 
 void FAndroidPlatformBugsnag::MarkLaunchCompleted()
 {
+	JNIEnv* Env = AndroidJavaEnv::GetJavaEnv(true);
+	ReturnVoidIf(!Env || !JNICache.initialized);
+	(*Env).CallStaticVoidMethod(JNICache.BugsnagClass, JNICache.BugsnagMarkLaunchCompleted);
+	FAndroidPlatformJNI::CheckAndClearException(Env);
 }
 
 TSharedPtr<FBugsnagLastRunInfo> FAndroidPlatformBugsnag::GetLastRunInfo()

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
@@ -116,6 +116,7 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 	CacheStaticJavaMethod(env, cache->BugsnagSetContext, cache->BugsnagClass, "setContext", "(Ljava/lang/String;)V");
 	CacheStaticJavaMethod(env, cache->BugsnagNotifyMethod, cache->InterfaceClass, "notify", "(Ljava/lang/String;Ljava/lang/String;Lcom/bugsnag/android/Severity;[Ljava/lang/StackTraceElement;)V");
 	CacheStaticJavaMethod(env, cache->BugsnagLeaveBreadcrumb, cache->BugsnagClass, "leaveBreadcrumb", "(Ljava/lang/String;Ljava/util/Map;Lcom/bugsnag/android/BreadcrumbType;)V");
+	CacheStaticJavaMethod(env, cache->BugsnagMarkLaunchCompleted, cache->BugsnagClass, "markLaunchCompleted", "()V");
 	CacheStaticJavaMethod(env, cache->BugsnagStartSession, cache->BugsnagClass, "startSession", "()V");
 	CacheStaticJavaMethod(env, cache->BugsnagResumeSession, cache->BugsnagClass, "resumeSession", "()Z");
 	CacheStaticJavaMethod(env, cache->BugsnagSetUser, cache->BugsnagClass, "setUser", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -67,6 +67,7 @@ typedef struct
 	jmethodID BugsnagNotifyMethod;
 	jmethodID BugsnagSetContext;
 	jmethodID BugsnagLeaveBreadcrumb;
+	jmethodID BugsnagMarkLaunchCompleted;
 	jmethodID BugsnagStartSession;
 	jmethodID BugsnagPauseSession;
 	jmethodID BugsnagResumeSession;

--- a/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
+++ b/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
@@ -2,6 +2,7 @@
 static TArray<FString> ScenarioNames = {
 	TEXT("BadMemoryAccessScenario"),
 	TEXT("CancelSessionScenario"),
+	TEXT("CrashAfterLaunchedScenario"),
 	TEXT("MaxConfigCrashScenario"),
 	TEXT("ModifyCrumbsScenario"),
 	TEXT("ModifySessionScenario"),

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/CrashAfterLaunchedScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/CrashAfterLaunchedScenario.cpp
@@ -1,0 +1,14 @@
+#include "Scenario.h"
+#include <cstdlib>
+
+class CrashAfterLaunchedScenario : public Scenario
+{
+public:
+	void Run() override
+	{
+		UBugsnagFunctionLibrary::MarkLaunchCompleted();
+		abort();
+	}
+};
+
+REGISTER_SCENARIO(CrashAfterLaunchedScenario);

--- a/features/support/scenario_names.rb
+++ b/features/support/scenario_names.rb
@@ -2,6 +2,7 @@
 $scenario_names = [
   'BadMemoryAccessScenario',
   'CancelSessionScenario',
+  'CrashAfterLaunchedScenario',
   'MaxConfigCrashScenario',
   'ModifyCrumbsScenario',
   'ModifySessionScenario',

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -67,3 +67,11 @@ Feature: Unhandled errors
     # TODO: pending on Android (PLAT-7305)
     And on iOS, the event "context" equals "Main Menu"
     And the method of stack frame 0 is equivalent to "MaxConfigCrashScenario::Run()"
+
+  Scenario: Crash after marking launch as completed
+    When I run "CrashAfterLaunchedScenario"
+    Then the app is not running
+    When I relaunch the app
+    And I configure Bugsnag for "MaxConfigCrashScenario"
+    And I wait to receive an error
+    Then the event "app.isLaunching" is false


### PR DESCRIPTION
## Changeset

* Small refactor to shorten some conditional returns
* Did the thing

## Testing

* Added a new crashing test which explicitly marks the launch as completed beforehand