### PR TITLE
Make FBugsnagConfiguration inherit from IBugsnagMetadataStore

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
@@ -138,7 +138,7 @@ void FAndroidPlatformBugsnag::SetUser(const FString& Id, const FString& Email, c
 	FAndroidPlatformJNI::CheckAndClearException(Env);
 }
 
-void FAndroidPlatformBugsnag::AddMetadata(const FString& Section, const TSharedPtr<FJsonObject>& Metadata)
+void FAndroidPlatformBugsnag::AddMetadata(const FString& Section, const TSharedRef<FJsonObject>& Metadata)
 {
 	JNIEnv* Env = AndroidJavaEnv::GetJavaEnv(true);
 	ReturnVoidIf(!Env || !JNICache.initialized);

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
@@ -18,7 +18,7 @@ public:
 
 	void SetUser(const FString& Id, const FString& Email, const FString& Name) override;
 
-	void AddMetadata(const FString& Section, const TSharedPtr<FJsonObject>& Metadata) override;
+	void AddMetadata(const FString& Section, const TSharedRef<FJsonObject>& Metadata) override;
 
 	void AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value) override;
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedMetadataStore.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedMetadataStore.h
@@ -13,7 +13,7 @@ public:
 	{
 	}
 
-	void AddMetadata(const FString& Section, const TSharedPtr<FJsonObject>& Metadata) override
+	void AddMetadata(const FString& Section, const TSharedRef<FJsonObject>& Metadata) override
 	{
 		[CocoaStore addMetadata:NSDictionaryFromFJsonObject(Metadata) toSection:NSStringFromFString(Section)];
 	}

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
@@ -134,7 +134,7 @@ void UBugsnagFunctionLibrary::SetUser(const FString& Id, const FString& Email, c
 #endif
 }
 
-void UBugsnagFunctionLibrary::AddMetadata(const FString& Section, const TSharedPtr<FJsonObject>& Metadata)
+void UBugsnagFunctionLibrary::AddMetadata(const FString& Section, const TSharedRef<FJsonObject>& Metadata)
 {
 #if PLATFORM_IMPLEMENTS_BUGSNAG
 	GPlatformBugsnag.AddMetadata(Section, Metadata);

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -3,6 +3,7 @@
 #include "BugsnagBreadcrumb.h"
 #include "BugsnagEndpointConfiguration.h"
 #include "BugsnagEvent.h"
+#include "BugsnagMetadataStore.h"
 #include "BugsnagSession.h"
 #include "BugsnagSettings.h"
 #include "BugsnagUser.h"
@@ -14,7 +15,7 @@ typedef TFunction<bool(TSharedRef<IBugsnagBreadcrumb>)> FBugsnagOnBreadcrumbCall
 typedef TFunction<bool(TSharedRef<IBugsnagEvent>)> FBugsnagOnErrorCallback;
 typedef TFunction<bool(TSharedRef<IBugsnagSession>)> FBugsnagOnSessionCallback;
 
-class BUGSNAG_API FBugsnagConfiguration
+class BUGSNAG_API FBugsnagConfiguration final : public IBugsnagMetadataStore
 {
 public:
 	FBugsnagConfiguration(const FString& ApiKey);
@@ -190,17 +191,17 @@ public:
 
 	// Metadata
 
-	void AddMetadata(const FString& Section, const TSharedRef<FJsonObject>& Metadata);
+	void AddMetadata(const FString& Section, const TSharedRef<FJsonObject>& Metadata) override;
 
-	void AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value);
+	void AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value) override;
 
-	TSharedPtr<FJsonObject> GetMetadata(const FString& Section);
+	TSharedPtr<FJsonObject> GetMetadata(const FString& Section) override;
 
-	TSharedPtr<FJsonValue> GetMetadata(const FString& Section, const FString& Key);
+	TSharedPtr<FJsonValue> GetMetadata(const FString& Section, const FString& Key) override;
 
-	void ClearMetadata(const FString& Section) { MetadataValues.Remove(Section); }
+	void ClearMetadata(const FString& Section) override { MetadataValues.Remove(Section); }
 
-	void ClearMetadata(const FString& Section, const FString& Key);
+	void ClearMetadata(const FString& Section, const FString& Key) override;
 
 	// Callbacks
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
@@ -66,7 +66,7 @@ public:
 
 	// Metadata
 
-	static void AddMetadata(const FString& Section, const TSharedPtr<FJsonObject>& Metadata);
+	static void AddMetadata(const FString& Section, const TSharedRef<FJsonObject>& Metadata);
 
 	static void AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value);
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagMetadataStore.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagMetadataStore.h
@@ -6,7 +6,7 @@
 class BUGSNAG_API IBugsnagMetadataStore
 {
 public:
-	virtual void AddMetadata(const FString& Section, const TSharedPtr<FJsonObject>& Metadata) = 0;
+	virtual void AddMetadata(const FString& Section, const TSharedRef<FJsonObject>& Metadata) = 0;
 
 	virtual void AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value) = 0;
 

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
@@ -31,7 +31,7 @@ public:
 				TSharedPtr<FBugsnagLastRunInfo> LastRunInfo = UBugsnagFunctionLibrary::GetLastRunInfo();
 				if (LastRunInfo.IsValid())
 				{
-					TSharedPtr<FJsonObject> Metadata = MakeShared<FJsonObject>();
+					TSharedRef<FJsonObject> Metadata = MakeShared<FJsonObject>();
 					Metadata->SetNumberField(TEXT("consecutiveLaunchCrashes"), LastRunInfo->GetConsecutiveLaunchCrashes());
 					Metadata->SetBoolField(TEXT("crashed"), LastRunInfo->GetCrashed());
 					Metadata->SetBoolField(TEXT("crashedDuringLaunch"), LastRunInfo->GetCrashedDuringLaunch());

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/NotifyScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/NotifyScenario.cpp
@@ -53,7 +53,7 @@ public:
 
 		UBugsnagFunctionLibrary::SetContext("pause menu");
 
-		TSharedPtr<FJsonObject> AdditionalValues = MakeShareable(new FJsonObject);
+		TSharedRef<FJsonObject> AdditionalValues = MakeShared<FJsonObject>();
 		AdditionalValues->SetStringField("someValue", "foobar");
 		AdditionalValues->SetBoolField("lastValue", true);
 		UBugsnagFunctionLibrary::AddMetadata("custom", AdditionalValues);


### PR DESCRIPTION
Minor tweak to make `FBugsnagConfiguration` inherit from `IBugsnagMetadataStore`, and make `IBugsnagMetadataStore::AddMetadata` take a non-nullable `FJsonObject` for spec compliance.