### PR TITLE
refactor: remove the ability to set error type

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/WrappedError.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/WrappedError.spec.cpp
@@ -42,13 +42,11 @@ void FWrappedErrorSpec::Define()
 					TSharedPtr<IBugsnagError> Error = FWrappedError::From(CocoaError);
 					Error->SetErrorClass(TEXT("Unreal Error"));
 					Error->SetErrorMessage(TEXT("Hello, Cocoa!"));
-					Error->SetErrorType(EBugsnagErrorType::C);
 					Error->SetStacktrace({});
 
 					TEST_EQUAL_OBJC(CocoaError.errorClass, @"Unreal Error");
 					TEST_EQUAL_OBJC(CocoaError.errorMessage, @"Hello, Cocoa!");
 					TEST_EQUAL_OBJC(CocoaError.stacktrace, @[]);
-					TEST_EQUAL((int)CocoaError.type, (int)BSGErrorTypeC);
 				});
 		});
 }

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedError.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedError.h
@@ -61,19 +61,6 @@ public:
 		}
 	}
 
-	void SetErrorType(EBugsnagErrorType Value) override
-	{
-		switch (Value)
-		{
-		case EBugsnagErrorType::C:
-			CocoaError.type = BSGErrorTypeC;
-			break;
-		case EBugsnagErrorType::Cocoa:
-			CocoaError.type = BSGErrorTypeCocoa;
-			break;
-		}
-	}
-
 	// stacktrace: Stacktrace;
 
 	TArray<TSharedRef<IBugsnagStackframe>> GetStacktrace() const override

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedThread.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedThread.h
@@ -67,19 +67,6 @@ public:
 		}
 	}
 
-	void SetErrorType(EBugsnagErrorType Value) override
-	{
-		switch (Value)
-		{
-		case EBugsnagErrorType::C:
-			UE_LOG(LogBugsnag, Warning, TEXT("EBugsnagErrorType::Cocoa is the only supported value for threads on Apple platforms"));
-			break;
-		case EBugsnagErrorType::Cocoa:
-			CocoaThread.type = BSGThreadTypeCocoa;
-			break;
-		}
-	}
-
 	// stacktrace: Stacktrace;
 
 	TArray<TSharedRef<IBugsnagStackframe>> GetStacktrace() const override

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagError.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagError.h
@@ -24,8 +24,6 @@ public:
 
 	virtual EBugsnagErrorType GetErrorType() const = 0;
 
-	virtual void SetErrorType(EBugsnagErrorType) = 0;
-
 	// stacktrace: Stacktrace;
 
 	virtual TArray<TSharedRef<IBugsnagStackframe>> GetStacktrace() const = 0;

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagThread.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagThread.h
@@ -28,8 +28,6 @@ public:
 
 	virtual EBugsnagErrorType GetErrorType() const = 0;
 
-	virtual void SetErrorType(EBugsnagErrorType) = 0;
-
 	// stacktrace: Stacktrace;
 
 	virtual TArray<TSharedRef<IBugsnagStackframe>> GetStacktrace() const = 0;


### PR DESCRIPTION
no values other than designated ones are valid, so unless we make specification changes, let's not confuse anybody.