### PR TITLE
fix: support negative line numbers

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedStackframe.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedStackframe.h
@@ -48,13 +48,13 @@ public:
 
 	// lineNumber?: number,
 
-	TSharedPtr<uint32> GetLineNumber() const override
+	TSharedPtr<int32> GetLineNumber() const override
 	{
 		// Not supported by bugsnag-cocoa
 		return nullptr;
 	}
 
-	void SetLineNumber(const TSharedPtr<uint32>&) override
+	void SetLineNumber(const TSharedPtr<int32>&) override
 	{
 		// Not supported by bugsnag-cocoa
 	}

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagStackframe.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagStackframe.h
@@ -21,9 +21,9 @@ public:
 
 	// lineNumber?: number,
 
-	virtual TSharedPtr<uint32> GetLineNumber() const = 0;
+	virtual TSharedPtr<int32> GetLineNumber() const = 0;
 
-	virtual void SetLineNumber(const TSharedPtr<uint32>&) = 0;
+	virtual void SetLineNumber(const TSharedPtr<int32>&) = 0;
 
 	// method?: string,
 


### PR DESCRIPTION
Negative numbers are used to denote native stack positions in Java stack traces