### PR TITLE
refactor(android): Create java object wrapper class

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidApp.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidApp.h
@@ -1,107 +1,81 @@
 #pragma once
 
-#include <jni.h>
-
 #include "BugsnagApp.h"
-#include "JNIUtilities.h"
-#include "Shorthand.h"
+#include "JavaObjectWrapper.h"
 
-class FAndroidApp : virtual public IBugsnagApp
+class FAndroidApp : virtual public IBugsnagApp, public FJavaObjectWrapper
 {
 public:
-	static TSharedRef<FAndroidApp> From(JNIEnv* Env, const JNIReferenceCache* Cache, jobject App)
-	{
-		return MakeShared<FAndroidApp>(Env, Cache, App);
-	}
-
-	FAndroidApp(JNIEnv* Env, const JNIReferenceCache* Cache, jobject App)
-		: App(App)
-		, Cache(Cache)
-		, Env(Env)
-	{
-	}
+	using FJavaObjectWrapper::FJavaObjectWrapper;
 
 	const TSharedPtr<FString> GetBinaryArch() const
 	{
-		ReturnStringFieldPtr(App, Cache->AppGetBinaryArch);
+		ReturnStringFieldPtr(JavaObject, Cache->AppGetBinaryArch);
 	}
 
 	void SetBinaryArch(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, App, Cache->AppSetBinaryArch, true, Value);
+		SetStringField(Cache->AppSetBinaryArch, true, Value);
 	}
 
 	const TSharedPtr<FString> GetBuildUuid() const
 	{
-		ReturnStringFieldPtr(App, Cache->AppGetBuildUuid);
+		ReturnStringFieldPtr(JavaObject, Cache->AppGetBuildUuid);
 	}
 
 	void SetBuildUuid(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, App, Cache->AppSetBuildUuid, true, Value);
+		SetStringField(Cache->AppSetBuildUuid, true, Value);
 	}
 
 	const TSharedPtr<FString> GetId() const
 	{
-		ReturnStringFieldPtr(App, Cache->AppGetId);
+		ReturnStringFieldPtr(JavaObject, Cache->AppGetId);
 	}
 
 	void SetId(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, App, Cache->AppSetId, true, Value);
+		SetStringField(Cache->AppSetId, true, Value);
 	}
 
 	const TSharedPtr<FString> GetReleaseStage() const
 	{
-		ReturnStringFieldPtr(App, Cache->AppGetReleaseStage);
+		ReturnStringFieldPtr(JavaObject, Cache->AppGetReleaseStage);
 	}
 
 	void SetReleaseStage(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, App, Cache->AppSetReleaseStage, true, Value);
+		SetStringField(Cache->AppSetReleaseStage, true, Value);
 	}
 
 	const TSharedPtr<FString> GetType() const
 	{
-		ReturnStringFieldPtr(App, Cache->AppGetType);
+		ReturnStringFieldPtr(JavaObject, Cache->AppGetType);
 	}
 
 	void SetType(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, App, Cache->AppSetType, true, Value);
+		SetStringField(Cache->AppSetType, true, Value);
 	}
 
 	const TSharedPtr<FString> GetVersion() const
 	{
-		ReturnStringFieldPtr(App, Cache->AppGetVersion);
+		ReturnStringFieldPtr(JavaObject, Cache->AppGetVersion);
 	}
 
 	void SetVersion(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, App, Cache->AppSetVersion, true, Value);
+		SetStringField(Cache->AppSetVersion, true, Value);
 	}
 
 	const TSharedPtr<int64> GetVersionCode() const
 	{
-		jlong VersionCode = (*Env).CallLongMethod(App, Cache->AppGetVersionCode);
-		return FAndroidPlatformJNI::CheckAndClearException(Env)
-				   ? nullptr
-				   : MakeShareable(new int64(VersionCode));
+		return GetLongObjectField<int64>(Cache->AppGetVersionCode);
 	}
 
 	void SetVersionCode(const TSharedPtr<int64>& Value)
 	{
-		jobject jVersionCode = nullptr;
-		if (Value.IsValid())
-		{
-			jVersionCode = FAndroidPlatformJNI::ParseInteger(Env, Cache, *Value);
-			if (!jVersionCode)
-			{
-				return; // avoid clearing the value when intended to set a value
-			}
-		}
-		(*Env).CallVoidMethod(App, Cache->AppSetVersionCode, jVersionCode);
-		FAndroidPlatformJNI::CheckAndClearException(Env);
+		SetLongObjectField(Cache->AppSetVersionCode, true, Value);
 	}
 
 	// -- unsupported fields
@@ -123,9 +97,4 @@ public:
 	void SetDsymUuid(const TSharedPtr<FString>& Value)
 	{
 	}
-
-private:
-	JNIEnv* Env;
-	const JNIReferenceCache* Cache;
-	const jobject App;
 };

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidDevice.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidDevice.h
@@ -1,162 +1,97 @@
 #pragma once
 
-#include <jni.h>
-
 #include "BugsnagDevice.h"
-#include "Containers/Array.h"
-#include "Dom/JsonObject.h"
-#include "JNIUtilities.h"
-#include "Shorthand.h"
-#include "Templates/SharedPointer.h"
+#include "JavaObjectWrapper.h"
 
-class FAndroidDevice : virtual public IBugsnagDevice
+class FAndroidDevice : virtual public IBugsnagDevice, public FJavaObjectWrapper
 {
 public:
-	static TSharedRef<FAndroidDevice> From(JNIEnv* Env, const JNIReferenceCache* Cache, jobject Device)
-	{
-		return MakeShared<FAndroidDevice>(Env, Cache, Device);
-	}
-
-	FAndroidDevice(JNIEnv* Env, const JNIReferenceCache* Cache, jobject Device)
-		: Device(Device)
-		, Cache(Cache)
-		, Env(Env)
-	{
-	}
+	using FJavaObjectWrapper::FJavaObjectWrapper;
 
 	const TSharedPtr<TArray<FString>> GetCpuAbi() const
 	{
-		TSharedPtr<TArray<FString>> ABIs = MakeShareable(new TArray<FString>);
-		jobjectArray jABIs = (jobjectArray)(*Env).CallObjectMethod(Device, Cache->DeviceGetCpuAbi);
-		if (FAndroidPlatformJNI::CheckAndClearException(Env))
-		{
-			return ABIs;
-		}
-		jsize length = (*Env).GetArrayLength(jABIs);
-		if (FAndroidPlatformJNI::CheckAndClearException(Env))
-		{
-			return ABIs;
-		}
-		for (jsize Index = 0; Index < length; Index++)
-		{
-			jobject jABI = (*Env).GetObjectArrayElement(jABIs, Index);
-			if (FAndroidPlatformJNI::CheckAndClearException(Env))
-			{
-				return ABIs;
-			}
-			ABIs->Add(FAndroidPlatformJNI::ParseJavaString(Env, Cache, jABI));
-		}
-		return ABIs;
+		return GetStringArrayField(Cache->DeviceGetCpuAbi);
 	}
 
 	void SetCpuAbi(const TSharedPtr<TArray<FString>>& Value)
 	{
-		jobjectArray jABIs = nullptr;
-		if (Value.IsValid())
-		{
-			int32 Length = (*Value).Num();
-			jABIs = (*Env).NewObjectArray(Length, Cache->StringClass, NULL);
-			ReturnVoidOnException(Env);
-			for (int32 Index = 0; Index < Length; Index++)
-			{
-				jstring jABI = FAndroidPlatformJNI::ParseFString(Env, (*Value)[Index]);
-				if (jABI)
-				{
-					(*Env).SetObjectArrayElement(jABIs, Index, jABI);
-					FAndroidPlatformJNI::CheckAndClearException(Env);
-				}
-			}
-		}
-		(*Env).CallVoidMethod(Device, Cache->DeviceSetCpuAbi, jABIs);
-		FAndroidPlatformJNI::CheckAndClearException(Env);
+		SetStringArrayField(Cache->DeviceSetCpuAbi, Value);
 	}
 
 	const TSharedPtr<FString> GetId() const
 	{
-		ReturnStringFieldPtr(Device, Cache->DeviceGetId);
+		ReturnStringFieldPtr(JavaObject, Cache->DeviceGetId);
 	}
 
 	void SetId(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, Device, Cache->DeviceSetId, true, Value);
+		SetStringField(Cache->DeviceSetId, true, Value);
 	}
 
 	TSharedPtr<bool> GetJailbroken() const
 	{
-		jboolean jValue = (*Env).CallBooleanMethod(Device, Cache->DeviceGetJailbroken);
-		return FAndroidPlatformJNI::CheckAndClearException(Env)
-				   ? nullptr
-				   : MakeShareable(new bool(jValue == JNI_TRUE));
+		return GetBoolObjectField(Cache->DeviceGetJailbroken);
 	}
 
 	void SetJailbroken(const TSharedPtr<bool>& Value)
 	{
-		if (Value.IsValid())
-		{
-			jboolean jValue = *Value ? JNI_TRUE : JNI_FALSE;
-			(*Env).CallVoidMethod(Device, Cache->DeviceSetJailbroken, jValue);
-		}
-		else
-		{
-			(*Env).CallVoidMethod(Device, Cache->DeviceSetJailbroken, nullptr);
-		}
-		FAndroidPlatformJNI::CheckAndClearException(Env);
+		SetBoolObjectField(Cache->DeviceSetJailbroken, true, Value);
 	}
 
 	const TSharedPtr<FString> GetLocale() const
 	{
-		ReturnStringFieldPtr(Device, Cache->DeviceGetLocale);
+		ReturnStringFieldPtr(JavaObject, Cache->DeviceGetLocale);
 	}
 
 	void SetLocale(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, Device, Cache->DeviceSetLocale, true, Value);
+		SetStringField(Cache->DeviceSetLocale, true, Value);
 	}
 
 	const TSharedPtr<FString> GetManufacturer() const
 	{
-		ReturnStringFieldPtr(Device, Cache->DeviceGetManufacturer);
+		ReturnStringFieldPtr(JavaObject, Cache->DeviceGetManufacturer);
 	}
 
 	void SetManufacturer(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, Device, Cache->DeviceSetManufacturer, true, Value);
+		SetStringField(Cache->DeviceSetManufacturer, true, Value);
 	}
 
 	const TSharedPtr<FString> GetModel() const
 	{
-		ReturnStringFieldPtr(Device, Cache->DeviceGetModel);
+		ReturnStringFieldPtr(JavaObject, Cache->DeviceGetModel);
 	}
 
 	void SetModel(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, Device, Cache->DeviceSetModel, true, Value);
+		SetStringField(Cache->DeviceSetModel, true, Value);
 	}
 
 	const TSharedPtr<FString> GetOsName() const
 	{
-		ReturnStringFieldPtr(Device, Cache->DeviceGetOsName);
+		ReturnStringFieldPtr(JavaObject, Cache->DeviceGetOsName);
 	}
 
 	void SetOsName(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, Device, Cache->DeviceSetOsName, true, Value);
+		SetStringField(Cache->DeviceSetOsName, true, Value);
 	}
 
 	const TSharedPtr<FString> GetOsVersion() const
 	{
-		ReturnStringFieldPtr(Device, Cache->DeviceGetOsVersion);
+		ReturnStringFieldPtr(JavaObject, Cache->DeviceGetOsVersion);
 	}
 
 	void SetOsVersion(const TSharedPtr<FString>& Value)
 	{
-		FAndroidPlatformJNI::SetStringValue(Env, Device, Cache->DeviceSetOsVersion, true, Value);
+		SetStringField(Cache->DeviceSetOsVersion, true, Value);
 	}
 
 	const TSharedPtr<TMap<FString, FString>> GetRuntimeVersions() const
 	{
 		TSharedPtr<TMap<FString, FString>> RuntimeVersions = MakeShareable(new TMap<FString, FString>);
-		jobject jRuntimeVersions = (*Env).CallObjectMethod(Device, Cache->DeviceGetRuntimeVersions);
+		jobject jRuntimeVersions = (*Env).CallObjectMethod(JavaObject, Cache->DeviceGetRuntimeVersions);
 		ReturnValueOnException(Env, RuntimeVersions);
 		jint jSize = (*Env).CallIntMethod(jRuntimeVersions, Cache->MapSize);
 		ReturnValueOnException(Env, RuntimeVersions);
@@ -166,7 +101,7 @@ public:
 		ReturnValueOnException(Env, RuntimeVersions);
 		for (jint Index = 0; Index < jSize; Index++)
 		{
-			jobject jVersionName = (*Env).CallObjectMethod(jKeyList, Cache->ArrayListGet, Index);
+			jobject jVersionName = (*Env).CallObjectMethod(jKeyList, Cache->ListGet, Index);
 			ContinueOnException(Env);
 			FString VersionName = FAndroidPlatformJNI::ParseJavaString(Env, Cache, jVersionName);
 			ContinueOnException(Env);
@@ -183,7 +118,7 @@ public:
 	{
 		if (!Value.IsValid())
 		{
-			(*Env).CallVoidMethod(Device, Cache->DeviceSetRuntimeVersions, nullptr);
+			(*Env).CallVoidMethod(JavaObject, Cache->DeviceSetRuntimeVersions, nullptr);
 			FAndroidPlatformJNI::CheckAndClearException(Env);
 			return;
 		}
@@ -196,27 +131,19 @@ public:
 		jobject jValues = FAndroidPlatformJNI::ParseJsonObject(Env, Cache, Values);
 		if (jValues)
 		{
-			(*Env).CallVoidMethod(Device, Cache->DeviceSetRuntimeVersions, jValues);
+			(*Env).CallVoidMethod(JavaObject, Cache->DeviceSetRuntimeVersions, jValues);
 			FAndroidPlatformJNI::CheckAndClearException(Env);
 		}
 	}
 
 	const TSharedPtr<uint64> GetTotalMemory() const
 	{
-		jlong jTotalMem = (*Env).CallLongMethod(Device, Cache->DeviceGetTotalMemory);
-		return FAndroidPlatformJNI::CheckAndClearException(Env)
-				   ? nullptr
-				   : MakeShareable(new uint64(jTotalMem));
+		return GetLongObjectField<uint64>(Cache->DeviceGetTotalMemory);
 	}
 
 	void SetTotalMemory(const TSharedPtr<uint64>& Value)
 	{
-		jobject jTotalMem = FAndroidPlatformJNI::ParseInteger(Env, Cache, Value.IsValid() ? *Value : 0);
-		if (jTotalMem)
-		{
-			(*Env).CallVoidMethod(Device, Cache->DeviceSetTotalMemory, jTotalMem);
-			FAndroidPlatformJNI::CheckAndClearException(Env);
-		}
+		SetLongObjectField(Cache->DeviceSetTotalMemory, true, Value);
 	}
 
 	// -- unsupported fields
@@ -229,9 +156,4 @@ public:
 	void SetModelNumber(const TSharedPtr<FString>& Value)
 	{
 	}
-
-private:
-	JNIEnv* Env;
-	const JNIReferenceCache* Cache;
-	const jobject Device;
 };

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
@@ -319,7 +319,7 @@ extern "C"
 	{
 		if (JNICache.loaded)
 		{
-			auto Crumb = FAndroidBreadcrumb::From(Env, &JNICache, jCrumb);
+			auto Crumb = MakeShared<FAndroidBreadcrumb>(Env, &JNICache, jCrumb);
 			return GPlatformBugsnag.RunOnBreadcrumbCallbacks(Crumb) ? JNI_TRUE : JNI_FALSE;
 		}
 		return JNI_TRUE;
@@ -330,7 +330,7 @@ extern "C"
 	{
 		if (JNICache.loaded)
 		{
-			auto Session = FAndroidSession::From(Env, &JNICache, jSession);
+			auto Session = MakeShared<FAndroidSession>(Env, &JNICache, jSession);
 			return GPlatformBugsnag.RunOnSessionCallbacks(Session) ? JNI_TRUE : JNI_FALSE;
 		}
 		return JNI_TRUE;

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -34,14 +34,16 @@ typedef struct
 	jclass HashMapClass;
 	jclass HashSetClass;
 	jclass ArrayListClass;
+	jclass BooleanClass;
 	jclass IntegerClass;
+	jclass ListClass;
+	jclass LongClass;
 	jclass MapClass;
+	jclass NumberClass;
 	jclass StringClass;
 
 	jmethodID ArrayListConstructor;
 	jmethodID ArrayListCollectionConstructor;
-	jmethodID ArrayListAdd;
-	jmethodID ArrayListGet;
 	jmethodID AppGetBinaryArch;
 	jmethodID AppGetBuildUuid;
 	jmethodID AppGetId;
@@ -154,13 +156,21 @@ typedef struct
 	jmethodID UserGetEmail;
 	jmethodID UserGetId;
 	jmethodID UserGetName;
+	jmethodID BooleanBooleanValue;
+	jmethodID BooleanConstructor;
 	jmethodID HashSetConstructor;
 	jmethodID HashSetAdd;
+	jmethodID ListAdd;
+	jmethodID ListGet;
+	jmethodID ListSize;
+	jmethodID LongConstructor;
 	jmethodID MetadataParserParse;
 	jmethodID MetadataSerializerSerialize;
 	jmethodID IntegerConstructor;
 	jmethodID MapKeySet;
 	jmethodID MapSize;
+	jmethodID NumberIntValue;
+	jmethodID NumberLongValue;
 	jmethodID TraceConstructor;
 
 	jfieldID SeverityFieldInfo;
@@ -374,13 +384,13 @@ public:
 	static bool SetNotifierInfo(JNIEnv* Env, const JNIReferenceCache* Cache, jobject jClient);
 
 	/**
-     * Call a void function with a string value
+     * Get the name of a Java enum value as a string
      *
      * @param Env        A JNI environment for the current thread
-     * @param Target     The object to call
-     * @param Method     The method to call
-     * @param IsNullable true if the method should be called with null if Value is invalid
-     * @param Value      the assigned value
+     * @param Cache      A populated reference cache
+     * @param EnumValue  The named value
+     *
+     * @return the name or null upon exception
      */
-	static void SetStringValue(JNIEnv* Env, jobject Target, jmethodID Method, bool IsNullable, const TSharedPtr<FString>& Value);
+	static const char* GetNameFromEnum(JNIEnv* Env, const JNIReferenceCache* Cache, jobject EnumValue);
 };

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JavaObjectWrapper.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JavaObjectWrapper.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include "JNIUtilities.h"
+#include "Shorthand.h"
+#include "Templates/SharedPointer.h"
+#include <jni.h>
+
+class FJavaObjectWrapper
+{
+public:
+	FJavaObjectWrapper(JNIEnv* Env, const JNIReferenceCache* Cache, jobject JavaObject)
+		: JavaObject(JavaObject)
+		, Cache(Cache)
+		, Env(Env)
+	{
+	}
+
+	jobject GetJavaObject() { return JavaObject; }
+
+	template <typename Interface, typename InstanceType>
+	TArray<TSharedRef<Interface>> GetListItems(jmethodID Method) const
+	{
+		TArray<TSharedRef<Interface>> Items;
+		jobject jItems = (*Env).CallObjectMethod(JavaObject, Method);
+		ReturnValueOnException(Env, Items);
+		jint Len = (*Env).CallIntMethod(jItems, Cache->ListSize);
+		ReturnValueOnException(Env, Items);
+		for (jint Index = 0; Index < Len; Index++)
+		{
+			jobject jItem = (*Env).CallObjectMethod(jItems, Cache->ListGet, Index);
+			ContinueOnException(Env);
+			Items.Add(MakeShared<InstanceType>(Env, Cache, jItem));
+		}
+		return Items;
+	}
+
+	template <typename T>
+	void SetPrimitiveObjectField(jclass PrimitiveClass, jmethodID PrimitiveConstructor, jmethodID Method, bool IsNullable, const TSharedPtr<T> Value) const
+	{
+		if (Value.IsValid())
+		{
+			jobject jValue = (*Env).NewObject(PrimitiveClass, PrimitiveConstructor, *Value);
+			ReturnVoidOnException(Env);
+			(*Env).CallVoidMethod(JavaObject, Method, jValue);
+		}
+		else if (IsNullable)
+		{
+			(*Env).CallVoidMethod(JavaObject, Method, nullptr);
+		}
+		FAndroidPlatformJNI::CheckAndClearException(Env);
+	}
+
+	template <typename T>
+	TSharedPtr<T> GetLongObjectField(jmethodID Method) const
+	{
+		jobject jValue = (*Env).CallObjectMethod(JavaObject, Method);
+		ReturnNullOnException(Env);
+		ReturnNullOnFail(jValue); // might be nullable
+		jlong Value = (*Env).CallLongMethod(jValue, Cache->NumberLongValue);
+		ReturnNullOnException(Env);
+		return MakeShareable(new T(Value));
+	}
+
+	template <typename T>
+	void SetLongObjectField(jmethodID Method, bool IsNullable, const TSharedPtr<T> Value) const
+	{
+		SetPrimitiveObjectField(Cache->LongClass, Cache->LongConstructor, Method, IsNullable, Value);
+	}
+
+	TSharedPtr<bool> GetBoolField(jmethodID Method)
+	{
+		jboolean jValue = (*Env).CallBooleanMethod(JavaObject, Method);
+		return FAndroidPlatformJNI::CheckAndClearException(Env)
+				   ? nullptr
+				   : MakeShareable(new bool(jValue == JNI_TRUE));
+	}
+
+	TSharedPtr<bool> GetBoolObjectField(jmethodID Method) const
+	{
+		jobject jValue = (*Env).CallObjectMethod(JavaObject, Method);
+		ReturnNullOnException(Env);
+		ReturnNullOnFail(jValue); // boolean objects are nullable
+		jboolean Value = (*Env).CallBooleanMethod(jValue, Cache->BooleanBooleanValue);
+		ReturnNullOnException(Env);
+		return MakeShareable(new bool(Value == JNI_TRUE));
+	}
+
+	void SetBoolObjectField(jmethodID Method, bool IsNullable, const TSharedPtr<bool> Value) const
+	{
+		TSharedPtr<jboolean> jValue = Value.IsValid() ? MakeShareable(new jboolean(*Value ? JNI_TRUE : JNI_FALSE)) : nullptr;
+		SetPrimitiveObjectField(Cache->BooleanClass, Cache->BooleanConstructor, Method, IsNullable, jValue);
+	}
+
+	void SetStringField(jmethodID Method, bool IsNullable, const TSharedPtr<FString>& Value) const
+	{
+		if (Value.IsValid())
+		{
+			jstring jString = FAndroidPlatformJNI::ParseFString(Env, *Value);
+			ReturnVoidIf(!jString);
+			(*Env).CallVoidMethod(JavaObject, Method, jString);
+			FAndroidPlatformJNI::CheckAndClearException(Env);
+		}
+		else if (IsNullable)
+		{
+			(*Env).CallVoidMethod(JavaObject, Method, nullptr);
+			FAndroidPlatformJNI::CheckAndClearException(Env);
+		}
+	}
+
+	const FString GetStringField(jmethodID Method) const
+	{
+		jobject jValue = (*Env).CallObjectMethod(JavaObject, Method);
+		FAndroidPlatformJNI::CheckAndClearException(Env);
+		return FAndroidPlatformJNI::ParseJavaString(Env, Cache, jValue);
+	}
+
+	const FDateTime GetDateField(jmethodID Method) const
+	{
+		jobject jValue = (*Env).CallObjectMethod(JavaObject, Method);
+		FAndroidPlatformJNI::CheckAndClearException(Env);
+		return FAndroidPlatformJNI::ParseDateTime(Env, Cache, jValue);
+	}
+
+	void SetDateField(jmethodID Method, bool IsNullable, TSharedPtr<FDateTime> Value) const
+	{
+		if (Value.IsValid())
+		{
+			jobject jValue = FAndroidPlatformJNI::ParseJavaDate(Env, Cache, *Value);
+			ReturnVoidOnException(Env);
+			(*Env).CallVoidMethod(JavaObject, Method, jValue);
+		}
+		else if (IsNullable)
+		{
+			(*Env).CallVoidMethod(JavaObject, Method, nullptr);
+		}
+		FAndroidPlatformJNI::CheckAndClearException(Env);
+	}
+
+	void SetField(jmethodID Method, bool IsNullable, jobject Value) const
+	{
+		ReturnVoidIf(!Value && !IsNullable);
+		(*Env).CallVoidMethod(JavaObject, Method, Value);
+		FAndroidPlatformJNI::CheckAndClearException(Env);
+	}
+
+	TSharedPtr<FJsonObject> GetJsonObjectField(jmethodID Method) const
+	{
+		jobject jValue = (*Env).CallObjectMethod(JavaObject, Method);
+		ReturnValueOnException(Env, MakeShareable(new FJsonObject));
+		return FAndroidPlatformJNI::ConvertJavaMapToJson(Env, Cache, jValue);
+	}
+
+	const TSharedPtr<TArray<FString>> GetStringArrayField(jmethodID Method) const
+	{
+		TSharedPtr<TArray<FString>> Array = MakeShareable(new TArray<FString>);
+		jobjectArray jArray = (jobjectArray)(*Env).CallObjectMethod(JavaObject, Method);
+		ReturnValueOnException(Env, Array);
+		jsize Len = (*Env).GetArrayLength(jArray);
+		ReturnValueOnException(Env, Array);
+		for (jsize Index = 0; Index < Len; Index++)
+		{
+			jobject jItem = (*Env).GetObjectArrayElement(jArray, Index);
+			ReturnValueOnException(Env, Array);
+			Array->Add(FAndroidPlatformJNI::ParseJavaString(Env, Cache, jItem));
+		}
+		return Array;
+	}
+
+	void SetStringArrayField(jmethodID Method, const TSharedPtr<TArray<FString>>& Value) const
+	{
+		jobjectArray jArray = nullptr;
+		if (Value.IsValid())
+		{
+			int32 Length = (*Value).Num();
+			jArray = (*Env).NewObjectArray(Length, Cache->StringClass, NULL);
+			ReturnVoidOnException(Env);
+			for (int32 Index = 0; Index < Length; Index++)
+			{
+				jstring jItem = FAndroidPlatformJNI::ParseFString(Env, (*Value)[Index]);
+				if (jItem)
+				{
+					(*Env).SetObjectArrayElement(jArray, Index, jItem);
+					FAndroidPlatformJNI::CheckAndClearException(Env);
+				}
+			}
+		}
+		(*Env).CallVoidMethod(JavaObject, Method, jArray);
+		FAndroidPlatformJNI::CheckAndClearException(Env);
+	}
+
+protected:
+	JNIEnv* Env;
+	const JNIReferenceCache* Cache;
+	const jobject JavaObject;
+};


### PR DESCRIPTION
## Goal

Consolidate getter/setter functions and native object access. Finalizing some structural changes now that I've gotten to the end of the callbacks and know it's not premature.

There is a wrapper class in the unreal codebase that I thought might be the direction needed, but it doesn't do any type conversions (e.g. Java List to TArray), which most of the complexity.

## Changeset

* Added a base class for all Java class wrappers
* Extended the wrapper class from Breadcrumb, Session, App, and Device

## Testing

The existing tests covered these changes already, and the consolidation should result in a general increase in coverage through shared implementations.