### PR TITLE
[PLAT-7312] Overload AddMetadata() for ease of use

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -250,7 +250,7 @@ void FApplePlatformConfigurationSpec::Define()
 			It("Metadata", [this]()
 				{
 					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
-					Configuration->AddMetadata(TEXT("Info"), TEXT("foo"), MakeShared<FJsonValueString>(TEXT("bar")));
+					Configuration->AddMetadata(TEXT("Info"), TEXT("foo"), TEXT("bar"));
 
 					TSharedRef<FJsonObject> JsonObject = MakeShared<FJsonObject>();
 					JsonObject->SetBoolField(TEXT("bHasCompletedLevel1"), true);

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedMetadataStore.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/WrappedMetadataStore.h
@@ -13,6 +13,8 @@ public:
 	{
 	}
 
+	using IBugsnagMetadataStore::AddMetadata;
+
 	void AddMetadata(const FString& Section, const TSharedRef<FJsonObject>& Metadata) override
 	{
 		[CocoaStore addMetadata:NSDictionaryFromFJsonObject(Metadata) toSection:NSStringFromFString(Section)];

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Specs/BugsnagConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Specs/BugsnagConfiguration.spec.cpp
@@ -196,11 +196,17 @@ void FBugsnagConfigurationSpec::Define()
 					Configuration.AddMetadata(TEXT("Info"), TEXT("foo"), MakeShared<FJsonValueString>(TEXT("baz")));
 					TEST_EQUAL(Configuration.GetMetadata(TEXT("Info"), TEXT("foo"))->AsString(), TEXT("baz"));
 
-					Configuration.AddMetadata(TEXT("Info"), TEXT("foo"), nullptr);
+					Configuration.AddMetadata(TEXT("Info"), TEXT("foo"), TSharedPtr<FJsonValue>(nullptr));
 					TEST_FALSE(Configuration.GetMetadata(TEXT("Info"), TEXT("foo")).IsValid());
 
 					Configuration.AddMetadata(TEXT("Info"), TEXT("name"), MakeShared<FJsonValueString>(TEXT("test")));
 					TEST_EQUAL(Configuration.GetMetadata(TEXT("Info"), TEXT("name"))->AsString(), TEXT("test"));
+
+					Configuration.AddMetadata(TEXT("Info"), TEXT("name"), TEXT("test_1"));
+					TEST_EQUAL(Configuration.GetMetadata(TEXT("Info"), TEXT("name"))->AsString(), TEXT("test_1"));
+
+					Configuration.AddMetadata(TEXT("Info"), TEXT("name"), "test_2");
+					TEST_EQUAL(Configuration.GetMetadata(TEXT("Info"), TEXT("name"))->AsString(), TEXT("test_2"));
 
 					Configuration.ClearMetadata(TEXT("Info"), TEXT("name"));
 					TEST_FALSE(Configuration.GetMetadata(TEXT("Info"), TEXT("name")).IsValid());

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -191,6 +191,8 @@ public:
 
 	// Metadata
 
+	using IBugsnagMetadataStore::AddMetadata;
+
 	void AddMetadata(const FString& Section, const TSharedRef<FJsonObject>& Metadata) override;
 
 	void AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value) override;

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
@@ -70,6 +70,76 @@ public:
 
 	static void AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value);
 
+	static void AddMetadata(const FString& Section, const FString& Key, const FString& Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueString>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, const TCHAR* Value)
+	{
+		AddMetadata(Section, Key, MakeShareable(Value ? new FJsonValueString(Value) : nullptr));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, const char* Value)
+	{
+		AddMetadata(Section, Key, MakeShareable(Value ? new FJsonValueString(Value) : nullptr));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, double Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, float Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, int8 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, int16 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, int32 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, int64 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, uint8 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, uint16 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, uint32 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, uint64 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	static void AddMetadata(const FString& Section, const FString& Key, bool Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueBoolean>(Value));
+	}
+
 	static TSharedPtr<FJsonObject> GetMetadata(const FString& Section);
 
 	static TSharedPtr<FJsonValue> GetMetadata(const FString& Section, const FString& Key);

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagMetadataStore.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagMetadataStore.h
@@ -10,6 +10,76 @@ public:
 
 	virtual void AddMetadata(const FString& Section, const FString& Key, const TSharedPtr<FJsonValue>& Value) = 0;
 
+	void AddMetadata(const FString& Section, const FString& Key, const FString& Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueString>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, const TCHAR* Value)
+	{
+		AddMetadata(Section, Key, MakeShareable(Value ? new FJsonValueString(Value) : nullptr));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, const char* Value)
+	{
+		AddMetadata(Section, Key, MakeShareable(Value ? new FJsonValueString(Value) : nullptr));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, double Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, float Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, int8 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, int16 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, int32 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, int64 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, uint8 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, uint16 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, uint32 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, uint64 Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueNumber>(Value));
+	}
+
+	void AddMetadata(const FString& Section, const FString& Key, bool Value)
+	{
+		AddMetadata(Section, Key, MakeShared<FJsonValueBoolean>(Value));
+	}
+
 	virtual TSharedPtr<FJsonObject> GetMetadata(const FString& Section) = 0;
 
 	virtual TSharedPtr<FJsonValue> GetMetadata(const FString& Section, const FString& Key) = 0;

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
@@ -26,16 +26,14 @@ public:
 
 		Configuration->AddOnSendError([](TSharedRef<IBugsnagEvent> Event)
 			{
-				Event->AddMetadata(TEXT("custom"), TEXT("configOnSendError"), MakeShareable(new FJsonValueString(TEXT("hello"))));
+				Event->AddMetadata(TEXT("custom"), TEXT("configOnSendError"), TEXT("hello"));
 
 				TSharedPtr<FBugsnagLastRunInfo> LastRunInfo = UBugsnagFunctionLibrary::GetLastRunInfo();
 				if (LastRunInfo.IsValid())
 				{
-					TSharedRef<FJsonObject> Metadata = MakeShared<FJsonObject>();
-					Metadata->SetNumberField(TEXT("consecutiveLaunchCrashes"), LastRunInfo->GetConsecutiveLaunchCrashes());
-					Metadata->SetBoolField(TEXT("crashed"), LastRunInfo->GetCrashed());
-					Metadata->SetBoolField(TEXT("crashedDuringLaunch"), LastRunInfo->GetCrashedDuringLaunch());
-					Event->AddMetadata(TEXT("lastRunInfo"), Metadata);
+					Event->AddMetadata(TEXT("lastRunInfo"), TEXT("consecutiveLaunchCrashes"), LastRunInfo->GetConsecutiveLaunchCrashes());
+					Event->AddMetadata(TEXT("lastRunInfo"), TEXT("crashed"), LastRunInfo->GetCrashed());
+					Event->AddMetadata(TEXT("lastRunInfo"), TEXT("crashedDuringLaunch"), LastRunInfo->GetCrashedDuringLaunch());
 				}
 
 				return true;
@@ -66,7 +64,7 @@ public:
 
 		UBugsnagFunctionLibrary::LeaveBreadcrumb(TEXT("About to read from a bad memory address"));
 
-		UBugsnagFunctionLibrary::AddMetadata(TEXT("custom"), TEXT("someValue"), MakeShareable(new FJsonValueString(TEXT("foobar"))));
+		UBugsnagFunctionLibrary::AddMetadata(TEXT("custom"), TEXT("someValue"), TEXT("foobar"));
 		TSharedPtr<FJsonObject> CustomMetadata = UBugsnagFunctionLibrary::GetMetadata("custom");
 		TSharedPtr<FJsonValue> ExistingValue = UBugsnagFunctionLibrary::GetMetadata("custom", "someValue");
 		if (CustomMetadata.IsValid() && ExistingValue.IsValid() && CustomMetadata->HasField("someValue"))

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/NotifyScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/NotifyScenario.cpp
@@ -24,7 +24,8 @@ public:
 
 		Configuration->AddOnSendError([](TSharedRef<IBugsnagEvent> Event)
 			{
-				Event->AddMetadata(TEXT("custom"), TEXT("configOnSendError"), MakeShareable(new FJsonValueString(TEXT("hello"))));
+				// Intentionally passing a char* value to check it isn't implicitly casted to a non-string type
+				Event->AddMetadata(TEXT("custom"), TEXT("configOnSendError"), "hello");
 				return true;
 			});
 
@@ -62,7 +63,7 @@ public:
 
 		UBugsnagFunctionLibrary::Notify(TEXT("Internal Error"), TEXT("Does not compute"), [](TSharedRef<IBugsnagEvent> Event)
 			{
-				Event->AddMetadata(TEXT("custom"), TEXT("notify"), MakeShareable(new FJsonValueString(TEXT("testing"))));
+				Event->AddMetadata(TEXT("custom"), TEXT("notify"), TEXT("testing"));
 				return true;
 			});
 	}

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/NotifyWithLaunchInfoScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/NotifyWithLaunchInfoScenario.cpp
@@ -16,12 +16,9 @@ public:
 				TSharedPtr<FBugsnagLastRunInfo> LastRunInfo = UBugsnagFunctionLibrary::GetLastRunInfo();
 				if (LastRunInfo.IsValid())
 				{
-					UBugsnagFunctionLibrary::AddMetadata("lastRunInfo", "consecutiveLaunchCrashes",
-						MakeShareable(new FJsonValueNumber(LastRunInfo->GetConsecutiveLaunchCrashes())));
-					UBugsnagFunctionLibrary::AddMetadata("lastRunInfo", "crashed",
-						MakeShareable(new FJsonValueBoolean(LastRunInfo->GetCrashed())));
-					UBugsnagFunctionLibrary::AddMetadata("lastRunInfo", "crashedDuringLaunch",
-						MakeShareable(new FJsonValueBoolean(LastRunInfo->GetCrashedDuringLaunch())));
+					UBugsnagFunctionLibrary::AddMetadata("lastRunInfo", "consecutiveLaunchCrashes", LastRunInfo->GetConsecutiveLaunchCrashes());
+					UBugsnagFunctionLibrary::AddMetadata("lastRunInfo", "crashed", LastRunInfo->GetCrashed());
+					UBugsnagFunctionLibrary::AddMetadata("lastRunInfo", "crashedDuringLaunch", LastRunInfo->GetCrashedDuringLaunch());
 				}
 
 				UBugsnagFunctionLibrary::Notify(TEXT("Resolution failed"), TEXT("invalid index (-1)"));


### PR DESCRIPTION
## Goal

Make it easier for developer to add metadata by removing the need for e.g. `MakeShared<FJsonValueString>` when adding values of common types - strings, numbers and bools.

## Changeset

Adds overloaded versions of the `AddMetadata(Section, Key, Value)` API.

Overloads for `char*` and `TCHAR*` were found to be necessary to prevent the compiler converting literal strings (including `TEXT("")`) into bools rather than FStrings.

## Testing

Amends E2E tests to take advantage of new overloads.

Adds unit test checks to verify string literals are not converted to undesired types.