### PR TITLE
refactor(android): implement notify wrapper in plugin

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
@@ -44,9 +44,6 @@ void FAndroidPlatformBugsnag::Notify(const FString& ErrorClass, const FString& M
 	jstring jMessage = FAndroidPlatformJNI::ParseFString(Env, Message);
 	ReturnVoidIf(!jErrorClass || !jMessage);
 
-	jobject jSeverity = FAndroidPlatformJNI::ParseSeverity(Env, &JNICache, EBugsnagSeverity::Warning);
-	ReturnVoidIf(!jSeverity);
-
 	jobjectArray jFrames = (*Env).NewObjectArray(StackTrace.Num(), JNICache.TraceClass, NULL);
 	ReturnVoidIf(!jFrames);
 
@@ -95,8 +92,9 @@ void FAndroidPlatformBugsnag::Notify(const FString& ErrorClass, const FString& M
 			}
 		}
 	}
-	(*Env).CallStaticVoidMethod(JNICache.InterfaceClass,
-		JNICache.BugsnagNotifyMethod, jErrorClass, jMessage, jSeverity, jFrames);
+	jobject jCallbackBuffer = nullptr;
+	(*Env).CallStaticVoidMethod(JNICache.BugsnagUnrealPluginClass,
+		JNICache.BugsnagUnrealPluginNotify, jErrorClass, jMessage, jFrames, jCallbackBuffer);
 	FAndroidPlatformJNI::CheckAndClearException(Env);
 	// TODO: handle callback
 }

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
@@ -72,7 +72,6 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 	CacheExternalJavaClass(env, cache->ErrorTypeClass, "com.bugsnag.android.ErrorType");
 	CacheExternalJavaClass(env, cache->ErrorTypesClass, "com.bugsnag.android.ErrorTypes");
 	CacheExternalJavaClass(env, cache->EventClass, "com.bugsnag.android.Event");
-	CacheExternalJavaClass(env, cache->InterfaceClass, "com.bugsnag.android.NativeInterface");
 	CacheExternalJavaClass(env, cache->LastRunInfoClass, "com.bugsnag.android.LastRunInfo");
 	CacheExternalJavaClass(env, cache->NotifierClass, "com.bugsnag.android.Notifier");
 	CacheExternalJavaClass(env, cache->BreadcrumbTypeClass, "com.bugsnag.android.BreadcrumbType");
@@ -141,7 +140,6 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 	CacheStaticJavaMethod(env, cache->BugsnagGetUser, cache->BugsnagClass, "getUser", "()Lcom/bugsnag/android/User;");
 	CacheStaticJavaMethod(env, cache->BugsnagStartMethod, cache->BugsnagClass, "start", "(Landroid/content/Context;Lcom/bugsnag/android/Configuration;)Lcom/bugsnag/android/Client;");
 	CacheStaticJavaMethod(env, cache->BugsnagSetContext, cache->BugsnagClass, "setContext", "(Ljava/lang/String;)V");
-	CacheStaticJavaMethod(env, cache->BugsnagNotifyMethod, cache->InterfaceClass, "notify", "(Ljava/lang/String;Ljava/lang/String;Lcom/bugsnag/android/Severity;[Ljava/lang/StackTraceElement;)V");
 	CacheStaticJavaMethod(env, cache->BugsnagLeaveBreadcrumb, cache->BugsnagClass, "leaveBreadcrumb", "(Ljava/lang/String;Ljava/util/Map;Lcom/bugsnag/android/BreadcrumbType;)V");
 	CacheStaticJavaMethod(env, cache->BugsnagMarkLaunchCompleted, cache->BugsnagClass, "markLaunchCompleted", "()V");
 	CacheStaticJavaMethod(env, cache->BugsnagStartSession, cache->BugsnagClass, "startSession", "()V");
@@ -153,6 +151,7 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 	CacheStaticJavaMethod(env, cache->BugsnagUnrealPluginGetEventMetadataValue, cache->BugsnagUnrealPluginClass, "getMetadata", "(Lcom/bugsnag/android/Event;Ljava/lang/String;Ljava/lang/String;)[B");
 	CacheStaticJavaMethod(env, cache->BugsnagUnrealPluginGetMetadataSection, cache->BugsnagUnrealPluginClass, "getMetadata", "(Ljava/lang/String;)[B");
 	CacheStaticJavaMethod(env, cache->BugsnagUnrealPluginGetMetadataValue, cache->BugsnagUnrealPluginClass, "getMetadata", "(Ljava/lang/String;Ljava/lang/String;)[B");
+	CacheStaticJavaMethod(env, cache->BugsnagUnrealPluginNotify, cache->BugsnagUnrealPluginClass, "notify", "(Ljava/lang/String;Ljava/lang/String;[Ljava/lang/StackTraceElement;Ljava/nio/ByteBuffer;)V");
 	CacheInstanceJavaMethod(env, cache->BugsnagUnrealPluginConstructor, cache->BugsnagUnrealPluginClass, "<init>", "()V");
 
 	CacheStaticJavaMethod(env, cache->MetadataParserParse, cache->MetadataParserClass, "parse", "([B)Ljava/util/Map;");

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -10,7 +10,6 @@ typedef struct
 {
 	bool loaded;
 	bool initialized;
-	jclass InterfaceClass;
 	jclass AppClass;
 	jclass AppWithStateClass;
 	jclass BreadcrumbClass;
@@ -101,6 +100,7 @@ typedef struct
 	jmethodID BugsnagUnrealPluginGetEventMetadataValue;
 	jmethodID BugsnagUnrealPluginGetMetadataSection;
 	jmethodID BugsnagUnrealPluginGetMetadataValue;
+	jmethodID BugsnagUnrealPluginNotify;
 	jmethodID ConfigAddMetadata;
 	jmethodID ConfigAddPlugin;
 	jmethodID ConfigConstructor;

--- a/deps/bugsnag-plugin-android-unreal/src/main/java/com/bugsnag/android/unreal/UnrealPlugin.java
+++ b/deps/bugsnag-plugin-android-unreal/src/main/java/com/bugsnag/android/unreal/UnrealPlugin.java
@@ -1,21 +1,27 @@
 package com.bugsnag.android.unreal;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Client;
 import com.bugsnag.android.Configuration;
 import com.bugsnag.android.Breadcrumb;
+import com.bugsnag.android.Error;
+import com.bugsnag.android.ErrorType;
 import com.bugsnag.android.Event;
 import com.bugsnag.android.OnBreadcrumbCallback;
+import com.bugsnag.android.OnErrorCallback;
 import com.bugsnag.android.OnSessionCallback;
 import com.bugsnag.android.Plugin;
 import com.bugsnag.android.Session;
+import com.bugsnag.android.Severity;
 
 public class UnrealPlugin implements Plugin {
-  Client client = null;
+  static Client client = null;
   OnBreadcrumbCallback onBreadcrumbRunner = new OnBreadcrumbCallback() {
     @Override
     public boolean onBreadcrumb(Breadcrumb crumb) {
@@ -62,12 +68,38 @@ public class UnrealPlugin implements Plugin {
     }
   }
 
+  static void notify(String name, String message, StackTraceElement[] stacktrace, ByteBuffer userdata) {
+    if (client == null) {
+      return;
+    }
+    Throwable exc = new RuntimeException();
+    exc.setStackTrace(stacktrace);
+
+    client.notify(exc, new OnErrorCallback() {
+      @Override
+      public boolean onError(Event event) {
+        List<Error> errors = event.getErrors();
+
+        if (!errors.isEmpty()) {
+          Error error = event.getErrors().get(0);
+          error.setErrorClass(name);
+          error.setErrorMessage(message);
+
+          for (Error err : errors) {
+            err.setType(ErrorType.C);
+          }
+        }
+        return true;
+      }
+    });
+  }
+
   static byte[] getMetadata(Event event, String section, String key) throws IOException {
     return section == null || key == null ? null : wrapAndSerialize(event.getMetadata(section, key));
   }
 
   static byte[] getMetadata(String section, String key) throws IOException {
-    return section == null || key == null ? null : wrapAndSerialize(Bugsnag.getMetadata(section, key));
+    return section == null || key == null || client == null ? null : wrapAndSerialize(client.getMetadata(section, key));
   }
 
   static byte[] getMetadata(Event event, String section) throws IOException {
@@ -75,7 +107,7 @@ public class UnrealPlugin implements Plugin {
   }
 
   static byte[] getMetadata(String section) throws IOException {
-    return section == null ? null : serialize(Bugsnag.getMetadata(section));
+    return section == null || client == null ? null : serialize(client.getMetadata(section));
   }
 
   private static byte[] serialize(Map<String, Object> metadata) throws IOException {


### PR DESCRIPTION
## Goal

Add a new plugin function for calling notify with a callback and an opaque native byte buffer which will be used to pass the native callback pointer to the JNI handler.

pr 2 of 4 implementing callback support on Android



## Design

`notify()` on the Java side will need to handle passing an extra argument which is there solely to pass back to the C++ layer when invoking the callback. For now the reference is null, as it will also be whenever `Notify()` is called without a callback.

```
-> C++ Notify() calls Java notify(name, msg, stack, callback_ptr)
   -> Java notify() creates an event, applying the name, msg, and stack
      -> [pending] Java notify() callback calls C runCallback() with the event and callback_ptr
         -> [pending] runCallback() wraps the event and passes it to the callback, returning a bool
      -> [pending] Java notify() returns the value of runCallback()
```

## Changeset

Implemented `notify()` in the `UnrealPlugin` class, replacing the existing calls to `NativeInterface` in the `bugsnag-android-core` package.

## Testing

[If everything goes as expected, existing tests will still pass as this refactor should not change behavior](https://tenor.com/v0Rf.gif) :crossed_fingers: 