### PR TITLE
Make UBugsnagFunctionLibrary::Start() take a TSharedRef

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
@@ -17,7 +17,7 @@ DEFINE_PLATFORM_BUGSNAG(FAndroidPlatformBugsnag);
 
 static JNIReferenceCache JNICache;
 
-void FAndroidPlatformBugsnag::Start(const TSharedPtr<FBugsnagConfiguration>& Config)
+void FAndroidPlatformBugsnag::Start(const TSharedRef<FBugsnagConfiguration>& Config)
 {
 	if (JNICache.loaded) // only attempt initialization once
 	{

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
@@ -5,7 +5,7 @@
 class FAndroidPlatformBugsnag : public IPlatformBugsnag
 {
 public:
-	void Start(const TSharedPtr<FBugsnagConfiguration>& Configuration) override;
+	void Start(const TSharedRef<FBugsnagConfiguration>& Configuration) override;
 
 	void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
 		const FBugsnagOnErrorCallback& Callback) override;

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
@@ -26,7 +26,7 @@
 
 jobject FAndroidPlatformConfiguration::Parse(JNIEnv* Env,
 	const JNIReferenceCache* Cache,
-	const TSharedPtr<FBugsnagConfiguration>& Config)
+	const TSharedRef<FBugsnagConfiguration>& Config)
 {
 	jstring jApiKey = FAndroidPlatformJNI::ParseFString(Env, Config->GetApiKey());
 	ReturnNullOnFail(jApiKey);

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.h
@@ -17,5 +17,5 @@ public:
    *
    * @return A Java configuration object or null if the configuration failed to initialize
    */
-	static jobject Parse(JNIEnv* Env, const JNIReferenceCache* Cache, const TSharedPtr<FBugsnagConfiguration>& Config);
+	static jobject Parse(JNIEnv* Env, const JNIReferenceCache* Cache, const TSharedRef<FBugsnagConfiguration>& Config);
 };

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
@@ -21,7 +21,7 @@
 
 DEFINE_PLATFORM_BUGSNAG(FApplePlatformBugsnag);
 
-void FApplePlatformBugsnag::Start(const TSharedPtr<FBugsnagConfiguration>& Configuration)
+void FApplePlatformBugsnag::Start(const TSharedRef<FBugsnagConfiguration>& Configuration)
 {
 	FWrappedMetadataStore::CocoaStore = [Bugsnag startWithConfiguration:FApplePlatformConfiguration::Configuration(Configuration)];
 }

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.h
@@ -6,7 +6,7 @@
 class FApplePlatformBugsnag : public IPlatformBugsnag, public FWrappedMetadataStore
 {
 public:
-	void Start(const TSharedPtr<FBugsnagConfiguration>& Configuration) override;
+	void Start(const TSharedRef<FBugsnagConfiguration>& Configuration) override;
 
 	void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
 		const FBugsnagOnErrorCallback& Callback) override;

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
@@ -53,7 +53,7 @@ static BugsnagErrorTypes* GetEnabledErrorTypes(FBugsnagErrorTypes EnabledErrorTy
 	return Types;
 }
 
-BugsnagConfiguration* FApplePlatformConfiguration::Configuration(const TSharedPtr<FBugsnagConfiguration>& Configuration)
+BugsnagConfiguration* FApplePlatformConfiguration::Configuration(const TSharedRef<FBugsnagConfiguration>& Configuration)
 {
 	BugsnagConfiguration* CocoaConfig = [[BugsnagConfiguration alloc] initWithApiKey:NSStringFromFString(Configuration->GetApiKey())];
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.h
@@ -7,5 +7,5 @@
 class FApplePlatformConfiguration
 {
 public:
-	static BugsnagConfiguration* Configuration(const TSharedPtr<FBugsnagConfiguration>& Configuration);
+	static BugsnagConfiguration* Configuration(const TSharedRef<FBugsnagConfiguration>& Configuration);
 };

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -28,7 +28,7 @@ void FApplePlatformConfigurationSpec::Define()
 		{
 			It("Defaults", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					BugsnagConfiguration* DefaultConfig = [[BugsnagConfiguration alloc] initWithApiKey:@(TCHAR_TO_UTF8(*ApiKey))];
 					TEST_TRUE(CocoaConfig.appHangThresholdMillis == DefaultConfig.appHangThresholdMillis);
@@ -49,14 +49,14 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("ApiKey", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.apiKey.UTF8String), ApiKey);
 				});
 
 			It("AutoDetectErrors", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetAutoDetectErrors(false);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(CocoaConfig.autoDetectErrors, Configuration->GetAutoDetectErrors());
@@ -64,7 +64,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("AutoTrackSessions", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetAutoTrackSessions(false);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(CocoaConfig.autoTrackSessions, Configuration->GetAutoTrackSessions());
@@ -72,7 +72,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("Context", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetContext(FString(TEXT("LevelOne")));
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.context.UTF8String), TEXT("LevelOne"));
@@ -80,7 +80,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("DiscardClasses", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetDiscardClasses({TEXT("Error1"), TEXT("Error2")});
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_TRUE([CocoaConfig.discardClasses containsObject:@"Error1"]);
@@ -89,7 +89,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("EnabledBreadcrumbTypes", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					FBugsnagEnabledBreadcrumbTypes EnabledBreadcrumbTypes;
 					EnabledBreadcrumbTypes.bLog = false;
 					Configuration->SetEnabledBreadcrumbTypes(EnabledBreadcrumbTypes);
@@ -99,7 +99,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("EnabledErrorTypes", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					FBugsnagErrorTypes EnabledErrorTypes;
 					EnabledErrorTypes.bOOMs = false;
 					Configuration->SetEnabledErrorTypes(EnabledErrorTypes);
@@ -109,7 +109,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("EnabledReleaseStages", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetEnabledReleaseStages({TEXT("production"), TEXT("staging")});
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_TRUE([CocoaConfig.enabledReleaseStages containsObject:@"production"]);
@@ -118,7 +118,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("RedactedKeys", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetRedactedKeys({TEXT("password"), TEXT("secret")});
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_TRUE([CocoaConfig.redactedKeys containsObject:@"password"]);
@@ -127,7 +127,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("AppHangThreshold", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetAppHangThresholdMillis(FBugsnagConfiguration::AppHangThresholdFatalOnly);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(CocoaConfig.appHangThresholdMillis, BugsnagAppHangThresholdFatalOnly);
@@ -139,7 +139,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("LaunchDurationMillis", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetLaunchDurationMillis(0);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL((int64)CocoaConfig.launchDurationMillis, (int64)0);
@@ -147,7 +147,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("SendLaunchCrashesSynchronously", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetSendLaunchCrashesSynchronously(false);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(CocoaConfig.sendLaunchCrashesSynchronously, NO);
@@ -155,7 +155,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("MaxBreadcrumbs", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetMaxBreadcrumbs(100);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL((int64)CocoaConfig.maxBreadcrumbs, (int64)100);
@@ -163,7 +163,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("MaxPersistedEvents", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetMaxPersistedEvents(100);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL((int64)CocoaConfig.maxPersistedEvents, (int64)100);
@@ -171,7 +171,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("MaxPersistedSessions", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetMaxPersistedSessions(100);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL((int64)CocoaConfig.maxPersistedSessions, (int64)100);
@@ -179,7 +179,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("PersistUser", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetPersistUser(false);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(CocoaConfig.persistUser, NO);
@@ -187,7 +187,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("ReleaseStage", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetReleaseStage(FString(TEXT("testing")));
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.releaseStage.UTF8String), TEXT("testing"));
@@ -195,7 +195,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("AppType", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetAppType(FString(TEXT("unreal")));
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.appType.UTF8String), TEXT("unreal"));
@@ -203,7 +203,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("AppVersion", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetAppVersion(FString(TEXT("1.2.3")));
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.appVersion.UTF8String), TEXT("1.2.3"));
@@ -211,7 +211,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("BundleVersion", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetBundleVersion(FString(TEXT("123.4")));
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.bundleVersion.UTF8String), TEXT("123.4"));
@@ -219,7 +219,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("Endpoints", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetEndpoints(TEXT("https://notify.example.com"), TEXT("https://sessions.example.com"));
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.endpoints.notify.UTF8String), TEXT("https://notify.example.com"));
@@ -228,7 +228,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("User", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetPersistUser(false);
 					Configuration->SetUser(
 						FString(TEXT("123")),
@@ -249,7 +249,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("Metadata", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->AddMetadata(TEXT("Info"), TEXT("foo"), TEXT("bar"));
 
 					TSharedRef<FJsonObject> JsonObject = MakeShared<FJsonObject>();
@@ -269,7 +269,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("Callbacks", [this]()
 				{
-					TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 
 					bool OnBreadcrumbCalled = false;
 					Configuration->AddOnBreadcrumb([&OnBreadcrumbCalled](TSharedRef<IBugsnagBreadcrumb> Breadcrumb) mutable

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
@@ -10,8 +10,7 @@
 
 void UBugsnagFunctionLibrary::Start(const FString& ApiKey)
 {
-	TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(ApiKey));
-	Start(Configuration);
+	Start(MakeShared<FBugsnagConfiguration>(ApiKey));
 }
 
 static TSharedRef<FJsonObject> MakeJsonObject(const FString& Key, const FString& Value)
@@ -21,7 +20,7 @@ static TSharedRef<FJsonObject> MakeJsonObject(const FString& Key, const FString&
 	return JsonObject;
 }
 
-void UBugsnagFunctionLibrary::Start(const TSharedPtr<FBugsnagConfiguration>& Configuration)
+void UBugsnagFunctionLibrary::Start(const TSharedRef<FBugsnagConfiguration>& Configuration)
 {
 #if PLATFORM_IMPLEMENTS_BUGSNAG
 	GPlatformBugsnag.Start(Configuration);

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagModule.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagModule.cpp
@@ -8,7 +8,7 @@ void FBugsnagModule::StartupModule()
 	TSharedPtr<FBugsnagConfiguration> Configuration = FBugsnagConfiguration::Load();
 	if (Configuration.IsValid() && !Configuration->GetApiKey().IsEmpty())
 	{
-		UBugsnagFunctionLibrary::Start(Configuration);
+		UBugsnagFunctionLibrary::Start(Configuration.ToSharedRef());
 	}
 }
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Interfaces/PlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Interfaces/PlatformBugsnag.h
@@ -11,7 +11,7 @@
 class IPlatformBugsnag : public virtual IBugsnagMetadataStore
 {
 public:
-	virtual void Start(const TSharedPtr<FBugsnagConfiguration>& Configuration) = 0;
+	virtual void Start(const TSharedRef<FBugsnagConfiguration>& Configuration) = 0;
 
 	virtual void Notify(const FString& ErrorClass, const FString& Message, const TArray<uint64>& StackTrace,
 		const FBugsnagOnErrorCallback& Callback) = 0;

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
@@ -22,7 +22,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Bugsnag")
 	static void Start(const FString& ApiKey);
 
-	static void Start(const TSharedPtr<FBugsnagConfiguration>& Configuration);
+	static void Start(const TSharedRef<FBugsnagConfiguration>& Configuration);
 
 	// Notify
 

--- a/Source/BugsnagExample/BugsnagExample.cpp
+++ b/Source/BugsnagExample/BugsnagExample.cpp
@@ -31,7 +31,7 @@ void StartWithConfiguration()
 	//
 	// Create an empty configuration object
 	//
-	TSharedPtr<FBugsnagConfiguration> Configuration(new FBugsnagConfiguration(TEXT("YOUR-API-KEY")));
+	TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(TEXT("YOUR-API-KEY"));
 
 	//
 	// This sets some user information that will be attached to each error.


### PR DESCRIPTION
## Goal

The implementations would crash given an invalid configuration pointer, so using `TSharedRef` adds some safety.
