### PR TITLE
build: separate ios-specific build steps

### DIFF
--- a/make/Android.make
+++ b/make/Android.make
@@ -28,6 +28,11 @@ endif
 	sed -i '' "s/version '.*'/version '$(VERSION)'/" deps/bugsnag-plugin-android-unreal/build.gradle
 	sed -i '' "s/com\.bugsnag,bugsnag-plugin-android-unreal,.*/com.bugsnag,bugsnag-plugin-android-unreal,$(VERSION)/" Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
 
+.PHONY: clean
+clean: ## remove build artifacts
+	@cd deps/bugsnag-plugin-android-unreal && \
+		$(GRADLE) clean
+
 $(PACKAGE_OUTPUT): $(PACKAGE_INPUT)
 	mkdir -p $(@D)
 	cp -a "$<" "$@"

--- a/make/Cocoa.make
+++ b/make/Cocoa.make
@@ -1,0 +1,60 @@
+.DELETE_ON_ERROR: # delete generated files if something fails
+.SUFFIXES:        # remove default suffix rules
+MAKEFLAGS += --no-builtin-rules # skip trying automatic rules (small speedup)
+
+BUGSNAG_COCOA_VERSION?=a93fbb6002727810b7040a48b7a88fc5debed691
+BUGSNAG_COCOA_SRC=deps/bugsnag-cocoa
+BUGSNAG_COCOA_SENTINEL=$(BUGSNAG_COCOA_SRC)/VERSION
+
+OUTDIR=Plugins/Bugsnag/Source/ThirdParty/BugsnagCocoa
+BUGSNAG_COCOA_INCLUDES_DEST=$(OUTDIR)/include
+BUGSNAG_COCOA_INCLUDES_SENTINEL=$(BUGSNAG_COCOA_INCLUDES_DEST)/Bugsnag/Bugsnag.h
+IOS_LIB=$(OUTDIR)/IOS/Release/libBugsnagStatic.a
+MAC_LIB=$(OUTDIR)/Mac/Release/libBugsnagStatic.a
+DERIVED_DATA=DerivedData
+IOS_LIB_SRC=$(BUGSNAG_COCOA_SRC)/$(DERIVED_DATA)/Build/Products/Release-iphoneos/libBugsnagStatic.a
+MAC_LIB_SRC=$(BUGSNAG_COCOA_SRC)/$(DERIVED_DATA)/Build/Products/Release/libBugsnagStatic.a
+
+.PHONY: package
+package: $(BUGSNAG_COCOA_INCLUDES_SENTINEL) $(IOS_LIB) $(MAC_LIB)
+
+.PHONY: clean
+clean:
+	@rm -rf $(BUGSNAG_COCOA_SRC)/$(DERIVED_DATA) $(OUTDIR)
+
+# Ensure the correct version of the library is checked out
+.PHONY: bugsnag_cocoa
+bugsnag_cocoa: $(BUGSNAG_COCOA_SENTINEL)
+ifneq ($(BUGSNAG_COCOA_VERSION),$(shell cat $(BUGSNAG_COCOA_SRC)/.git/HEAD | tr -d "\n"))
+	cd $(BUGSNAG_COCOA_SRC) \
+		&& git fetch --no-tags --depth=1 origin $(BUGSNAG_COCOA_VERSION) \
+		&& git checkout --quiet -f $(BUGSNAG_COCOA_VERSION)
+endif
+
+$(BUGSNAG_COCOA_INCLUDES_SENTINEL): bugsnag_cocoa
+	cp -pR $(BUGSNAG_COCOA_SRC)/Bugsnag/include/ $(BUGSNAG_COCOA_INCLUDES_DEST)/
+	mkdir -p $(BUGSNAG_COCOA_INCLUDES_DEST)/BugsnagPrivate
+	cd $(BUGSNAG_COCOA_SRC) \
+		&& find Bugsnag \( -name '*.h' ! -path 'Bugsnag/include/*' \) \
+			-exec cp -a {} $(PWD)/$(BUGSNAG_COCOA_INCLUDES_DEST)/BugsnagPrivate \;
+
+$(BUGSNAG_COCOA_SENTINEL):
+	git clone --quiet --no-checkout https://github.com/bugsnag/bugsnag-cocoa $(@D)
+
+$(IOS_LIB): $(IOS_LIB_SRC)
+	mkdir -p $(@D)
+	cp -a $< $@
+
+$(MAC_LIB): $(MAC_LIB_SRC)
+	mkdir -p $(@D)
+	cp -a $< $@
+
+$(IOS_LIB_SRC): bugsnag_cocoa
+	cd $(BUGSNAG_COCOA_SRC) && xcodebuild -scheme BugsnagStatic \
+		-derivedDataPath $(DERIVED_DATA) -configuration Release -quiet build \
+		SDKROOT=iphoneos IOS_DEPLOYMENT_TARGET=11.0
+
+$(MAC_LIB_SRC):  bugsnag_cocoa
+	cd $(BUGSNAG_COCOA_SRC) && xcodebuild -scheme BugsnagStatic \
+		-derivedDataPath $(DERIVED_DATA) -configuration Release -quiet build \
+		SDKROOT=macosx MACOSX_DEPLOYMENT_TARGET=10.11


### PR DESCRIPTION
## Goal

*  separate the iOS parts of the build steps into its own makefile
*  automatically handle validating and checking out a different revision if the cocoa dependency version changes
*  add help text. it looks like this:

   ![help text example](https://user-images.githubusercontent.com/333454/139672048-e43d3177-b60a-488e-b3d6-7bc7c715d212.png)

*  add platform-specific behaviour for clean, e2e, test
*  switched to sentinel file-based targets instead of directories so change detection works a bit better

ref: [this blog post](https://tech.davis-hansson.com/p/make/), which I cribbed some of my style from. (some parts I opted against (e.g. `.ONESHELL`) since the default `make` on macOS is ancient and doesn't support it.)

## Testing

* built the package locally via `make package`
* ran the e2e tests locally on both iOS and Android