### PR TITLE
Eager concurrency

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,6 +109,7 @@ steps:
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
+    concurrency_method: eager
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -138,6 +139,7 @@ steps:
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
+    concurrency_method: eager
     retry:
       automatic:
         - exit_status: -1  # Agent was lost


### PR DESCRIPTION
## Goal

Implement eager concurrency for the CI browserstack-app concurrency group.

## Design

By default, Buildkite processes jobs in the order in which they were created, which is often very inefficient for our needs.  Jobs that are ready to be processed can be held behind those that are still waiting for other steps to complete.  

## Changeset

Setting `concurrency_method` to `eager` is Buildkite's mechanism to avoid this situation and is perfect for our needs.

## Testing

Covered by CI.