### PR TITLE
Add EBugsnagEnabledBreadcrumbTypes

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
@@ -528,21 +528,21 @@ jobject FAndroidPlatformJNI::ParseBreadcrumbType(JNIEnv* Env, const JNIReference
 	return result;
 }
 
-jobject FAndroidPlatformJNI::ParseBreadcrumbTypeSet(JNIEnv* Env, const JNIReferenceCache* Cache, const FBugsnagEnabledBreadcrumbTypes Value)
+jobject FAndroidPlatformJNI::ParseBreadcrumbTypeSet(JNIEnv* Env, const JNIReferenceCache* Cache, const EBugsnagEnabledBreadcrumbTypes Value)
 {
 	jobject jSet = (*Env).NewObject(Cache->HashSetClass, Cache->HashSetConstructor);
 	if (FAndroidPlatformJNI::CheckAndClearException(Env))
 	{
 		return nullptr;
 	}
-	if (addTypeToSet(Env, jSet, Value.bError, Cache, Cache->BreadcrumbTypeError) &&
-		addTypeToSet(Env, jSet, Value.bLog, Cache, Cache->BreadcrumbTypeLog) &&
-		addTypeToSet(Env, jSet, Value.bManual, Cache, Cache->BreadcrumbTypeManual) &&
-		addTypeToSet(Env, jSet, Value.bNavigation, Cache, Cache->BreadcrumbTypeNavigation) &&
-		addTypeToSet(Env, jSet, Value.bProcess, Cache, Cache->BreadcrumbTypeProcess) &&
-		addTypeToSet(Env, jSet, Value.bRequest, Cache, Cache->BreadcrumbTypeRequest) &&
-		addTypeToSet(Env, jSet, Value.bState, Cache, Cache->BreadcrumbTypeState) &&
-		addTypeToSet(Env, jSet, Value.bUser, Cache, Cache->BreadcrumbTypeUser))
+	if (addTypeToSet(Env, jSet, EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Error), Cache, Cache->BreadcrumbTypeError) &&
+		addTypeToSet(Env, jSet, EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Log), Cache, Cache->BreadcrumbTypeLog) &&
+		addTypeToSet(Env, jSet, EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Manual), Cache, Cache->BreadcrumbTypeManual) &&
+		addTypeToSet(Env, jSet, EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Navigation), Cache, Cache->BreadcrumbTypeNavigation) &&
+		addTypeToSet(Env, jSet, EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Process), Cache, Cache->BreadcrumbTypeProcess) &&
+		addTypeToSet(Env, jSet, EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Request), Cache, Cache->BreadcrumbTypeRequest) &&
+		addTypeToSet(Env, jSet, EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::State), Cache, Cache->BreadcrumbTypeState) &&
+		addTypeToSet(Env, jSet, EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::User), Cache, Cache->BreadcrumbTypeUser))
 	{
 		return jSet;
 	}

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -347,7 +347,7 @@ public:
    *
    * @return A Java object reference or null on failure
    */
-	static jobject ParseBreadcrumbTypeSet(JNIEnv* Env, const JNIReferenceCache* Cache, const FBugsnagEnabledBreadcrumbTypes Value);
+	static jobject ParseBreadcrumbTypeSet(JNIEnv* Env, const JNIReferenceCache* Cache, const EBugsnagEnabledBreadcrumbTypes Value);
 
 	/**
    * Convert a value into a Java Severity

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
@@ -19,6 +19,18 @@ static TOptional<T> UnsetIfZero(const T Value)
 	return Value == 0 ? TOptional<T>() : Value;
 }
 
+static EBugsnagEnabledBreadcrumbTypes Convert(FBugsnagEnabledBreadcrumbTypes Value)
+{
+	return (Value.bManual ? EBugsnagEnabledBreadcrumbTypes::Manual : EBugsnagEnabledBreadcrumbTypes::None) |
+		   (Value.bError ? EBugsnagEnabledBreadcrumbTypes::Error : EBugsnagEnabledBreadcrumbTypes::None) |
+		   (Value.bLog ? EBugsnagEnabledBreadcrumbTypes::Log : EBugsnagEnabledBreadcrumbTypes::None) |
+		   (Value.bNavigation ? EBugsnagEnabledBreadcrumbTypes::Navigation : EBugsnagEnabledBreadcrumbTypes::None) |
+		   (Value.bProcess ? EBugsnagEnabledBreadcrumbTypes::Process : EBugsnagEnabledBreadcrumbTypes::None) |
+		   (Value.bRequest ? EBugsnagEnabledBreadcrumbTypes::Request : EBugsnagEnabledBreadcrumbTypes::None) |
+		   (Value.bState ? EBugsnagEnabledBreadcrumbTypes::State : EBugsnagEnabledBreadcrumbTypes::None) |
+		   (Value.bUser ? EBugsnagEnabledBreadcrumbTypes::User : EBugsnagEnabledBreadcrumbTypes::None);
+}
+
 uint64 const FBugsnagConfiguration::AppHangThresholdFatalOnly = INT_MAX;
 
 FBugsnagConfiguration::FBugsnagConfiguration(const FString& ApiKey)
@@ -32,7 +44,7 @@ FBugsnagConfiguration::FBugsnagConfiguration(const UBugsnagSettings& Settings)
 	, bAutoTrackSessions(Settings.bAutoTrackSessions)
 	, Context(UnsetIfEmpty(Settings.Context))
 	, DiscardClasses(Settings.DiscardClasses)
-	, EnabledBreadcrumbTypes(Settings.EnabledBreadcrumbTypes)
+	, EnabledBreadcrumbTypes(Convert(Settings.EnabledBreadcrumbTypes))
 	, EnabledErrorTypes(Settings.EnabledErrorTypes)
 	, EnabledReleaseStages(Settings.EnabledReleaseStages)
 	, RedactedKeys(Settings.RedactedKeys)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/IOS/ApplePlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/IOS/ApplePlatformConfiguration.cpp
@@ -28,15 +28,16 @@ static BSGThreadSendPolicy GetThreadSendPolicy(EBugsnagSendThreadsPolicy Policy)
 	return BSGThreadSendPolicyAlways;
 }
 
-static BSGEnabledBreadcrumbType GetEnabledBreadcrumbTypes(FBugsnagEnabledBreadcrumbTypes EnabledBreadcrumbTypes)
+static BSGEnabledBreadcrumbType GetEnabledBreadcrumbTypes(EBugsnagEnabledBreadcrumbTypes Value)
 {
-	return (EnabledBreadcrumbTypes.bError ? BSGEnabledBreadcrumbTypeError : 0) |
-		   (EnabledBreadcrumbTypes.bLog ? BSGEnabledBreadcrumbTypeLog : 0) |
-		   (EnabledBreadcrumbTypes.bNavigation ? BSGEnabledBreadcrumbTypeNavigation : 0) |
-		   (EnabledBreadcrumbTypes.bProcess ? BSGEnabledBreadcrumbTypeProcess : 0) |
-		   (EnabledBreadcrumbTypes.bRequest ? BSGEnabledBreadcrumbTypeRequest : 0) |
-		   (EnabledBreadcrumbTypes.bState ? BSGEnabledBreadcrumbTypeState : 0) |
-		   (EnabledBreadcrumbTypes.bUser ? BSGEnabledBreadcrumbTypeUser : 0);
+	// Note: There is no BSGEnabledBreadcrumbTypeManual
+	return (EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Error) ? BSGEnabledBreadcrumbTypeError : 0) |
+		   (EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Log) ? BSGEnabledBreadcrumbTypeLog : 0) |
+		   (EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Navigation) ? BSGEnabledBreadcrumbTypeNavigation : 0) |
+		   (EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Process) ? BSGEnabledBreadcrumbTypeProcess : 0) |
+		   (EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::Request) ? BSGEnabledBreadcrumbTypeRequest : 0) |
+		   (EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::State) ? BSGEnabledBreadcrumbTypeState : 0) |
+		   (EnumHasAllFlags(Value, EBugsnagEnabledBreadcrumbTypes::User) ? BSGEnabledBreadcrumbTypeUser : 0);
 }
 
 static BugsnagErrorTypes* GetEnabledErrorTypes(FBugsnagErrorTypes EnabledErrorTypes)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/IOS/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/IOS/Specs/ApplePlatformConfiguration.spec.cpp
@@ -90,9 +90,7 @@ void FApplePlatformConfigurationSpec::Define()
 			It("EnabledBreadcrumbTypes", [this]()
 				{
 					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
-					FBugsnagEnabledBreadcrumbTypes EnabledBreadcrumbTypes;
-					EnabledBreadcrumbTypes.bLog = false;
-					Configuration->SetEnabledBreadcrumbTypes(EnabledBreadcrumbTypes);
+					Configuration->SetEnabledBreadcrumbTypes(EBugsnagEnabledBreadcrumbTypes::All & ~EBugsnagEnabledBreadcrumbTypes::Log);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(CocoaConfig.enabledBreadcrumbTypes, BSGEnabledBreadcrumbTypeAll & ~BSGEnabledBreadcrumbTypeLog);
 				});

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Specs/BugsnagConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Specs/BugsnagConfiguration.spec.cpp
@@ -77,6 +77,15 @@ void FBugsnagConfigurationSpec::Define()
 				});
 		});
 
+	Describe("EnabledBreadcrumbTypes", [this]()
+		{
+			It("All are enabled by default", [this]()
+				{
+					TEST_EQUAL(FBugsnagConfiguration(ValidApiKey).GetEnabledBreadcrumbTypes(), EBugsnagEnabledBreadcrumbTypes::All);
+					TEST_EQUAL(FBugsnagConfiguration::Load()->GetEnabledBreadcrumbTypes(), EBugsnagEnabledBreadcrumbTypes::All);
+				});
+		});
+
 	Describe("Endpoints", [this]()
 		{
 			It("Should have sensible defaults", [this]()

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagBreadcrumb.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagBreadcrumb.h
@@ -18,6 +18,21 @@ enum class EBugsnagBreadcrumbType : uint8
 	User
 };
 
+enum class EBugsnagEnabledBreadcrumbTypes : uint8
+{
+	None = 0,
+	Manual = 1 << 0,
+	Error = 1 << 1,
+	Log = 1 << 2,
+	Navigation = 1 << 3,
+	Process = 1 << 4,
+	Request = 1 << 5,
+	State = 1 << 6,
+	User = 1 << 7,
+	All = Manual | Error | Log | Navigation | Process | Request | State | User
+};
+ENUM_CLASS_FLAGS(EBugsnagEnabledBreadcrumbTypes)
+
 class BUGSNAG_API IBugsnagBreadcrumb
 {
 public:

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -54,9 +54,9 @@ public:
 
 	// Enabled Breadcrumb Types
 
-	const FBugsnagEnabledBreadcrumbTypes GetEnabledBreadcrumbTypes() const { return EnabledBreadcrumbTypes; }
+	const EBugsnagEnabledBreadcrumbTypes GetEnabledBreadcrumbTypes() const { return EnabledBreadcrumbTypes; }
 
-	void SetEnabledBreadcrumbTypes(FBugsnagEnabledBreadcrumbTypes Value) { EnabledBreadcrumbTypes = Value; }
+	void SetEnabledBreadcrumbTypes(EBugsnagEnabledBreadcrumbTypes Value) { EnabledBreadcrumbTypes = Value; }
 
 	// Enabled Error Types
 
@@ -251,7 +251,7 @@ private:
 	bool bAutoTrackSessions = true;
 	TOptional<FString> Context;
 	TArray<FString> DiscardClasses;
-	FBugsnagEnabledBreadcrumbTypes EnabledBreadcrumbTypes;
+	EBugsnagEnabledBreadcrumbTypes EnabledBreadcrumbTypes = EBugsnagEnabledBreadcrumbTypes::All;
 	FBugsnagErrorTypes EnabledErrorTypes;
 	TArray<FString> EnabledReleaseStages;
 	TArray<FString> RedactedKeys = {TEXT("password")};

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/OpenLevelBreadcrumbsScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/OpenLevelBreadcrumbsScenario.cpp
@@ -7,16 +7,7 @@ class OpenLevelBreadcrumbsScenario : public Scenario
 public:
 	void Configure() override
 	{
-		FBugsnagEnabledBreadcrumbTypes BugsnagEnabledBreadcrumbTypes;
-		BugsnagEnabledBreadcrumbTypes.bError = false;
-		BugsnagEnabledBreadcrumbTypes.bLog = false;
-		BugsnagEnabledBreadcrumbTypes.bManual = false;
-		BugsnagEnabledBreadcrumbTypes.bNavigation = true;
-		BugsnagEnabledBreadcrumbTypes.bProcess = false;
-		BugsnagEnabledBreadcrumbTypes.bRequest = false;
-		BugsnagEnabledBreadcrumbTypes.bState = false;
-		BugsnagEnabledBreadcrumbTypes.bUser = false;
-		Configuration->SetEnabledBreadcrumbTypes(BugsnagEnabledBreadcrumbTypes);
+		Configuration->SetEnabledBreadcrumbTypes(EBugsnagEnabledBreadcrumbTypes::Navigation);
 	}
 
 	void Run() override


### PR DESCRIPTION
## Goal

Make it easier to enable or disable a single breadcrumb type on the configuration object, for example:

```diff
- FBugsnagEnabledBreadcrumbTypes BugsnagEnabledBreadcrumbTypes;
- BugsnagEnabledBreadcrumbTypes.bError = false;
- BugsnagEnabledBreadcrumbTypes.bLog = false;
- BugsnagEnabledBreadcrumbTypes.bManual = false;
- BugsnagEnabledBreadcrumbTypes.bNavigation = true;
- BugsnagEnabledBreadcrumbTypes.bProcess = false;
- BugsnagEnabledBreadcrumbTypes.bRequest = false;
- BugsnagEnabledBreadcrumbTypes.bState = false;
- BugsnagEnabledBreadcrumbTypes.bUser = false;
- Configuration->SetEnabledBreadcrumbTypes(BugsnagEnabledBreadcrumbTypes);
+ Configuration->SetEnabledBreadcrumbTypes(EBugsnagEnabledBreadcrumbTypes::Navigation);
```

## Changeset

Adds a new enum `EBugsnagEnabledBreadcrumbTypes` that is exposed on the configuration object.

Code that used `FBugsnagEnabledBreadcrumbTypes` has been adapted to use the new enum.

## Testing

Unit test case has been added to verify conversion from `FBugsnagEnabledBreadcrumbTypes` (used by the settings object.)