### PR TITLE
[PLAT-7556] Automatically set context to level / map name

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
@@ -43,6 +43,7 @@ FBugsnagConfiguration::FBugsnagConfiguration(const UBugsnagSettings& Settings)
 	: bAutoDetectErrors(Settings.bAutoDetectErrors)
 	, bAutoTrackSessions(Settings.bAutoTrackSessions)
 	, Context(UnsetIfEmpty(Settings.Context))
+	, bHasCustomContext(Context.IsSet())
 	, DiscardClasses(Settings.DiscardClasses)
 	, EnabledBreadcrumbTypes(Convert(Settings.EnabledBreadcrumbTypes))
 	, EnabledErrorTypes(Settings.EnabledErrorTypes)
@@ -252,6 +253,11 @@ void FBugsnagConfiguration::AddDefaultMetadata()
 			EngineMetadata->SetStringField(BugsnagConstants::GameStateName, CurrentPlayWorld->GetGameState()->GetClass()->GetName());
 		}
 		EngineMetadata->SetStringField(BugsnagConstants::MapUrl, CurrentPlayWorld->GetLocalURL());
+
+		if (!Context.IsSet())
+		{
+			Context = CurrentPlayWorld->GetLocalURL();
+		}
 	}
 
 	EngineMetadata->SetStringField(BugsnagConstants::UserActivity, FUserActivityTracking::GetUserActivity().ActionName);

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
@@ -20,10 +20,14 @@ static TSharedRef<FJsonObject> MakeJsonObject(const FString& Key, const FString&
 	return JsonObject;
 }
 
+static bool bHasCustomContext;
+
 void UBugsnagFunctionLibrary::Start(const TSharedRef<FBugsnagConfiguration>& Configuration)
 {
 #if PLATFORM_IMPLEMENTS_BUGSNAG
 	GPlatformBugsnag.Start(Configuration);
+
+	bHasCustomContext = Configuration->bHasCustomContext;
 
 	FCoreUObjectDelegates::PreLoadMap.AddLambda([](const FString& MapUrl)
 		{
@@ -32,6 +36,10 @@ void UBugsnagFunctionLibrary::Start(const TSharedRef<FBugsnagConfiguration>& Con
 				MakeJsonObject(BugsnagConstants::Url, MapUrl), EBugsnagBreadcrumbType::Navigation);
 			GPlatformBugsnag.AddMetadata(BugsnagConstants::UnrealEngine, BugsnagConstants::MapUrl,
 				MakeShared<FJsonValueString>(MapUrl));
+			if (!bHasCustomContext)
+			{
+				GPlatformBugsnag.SetContext(MapUrl);
+			}
 		});
 
 	FCoreUObjectDelegates::PostLoadMapWithWorld.AddLambda([](UWorld* World)
@@ -113,6 +121,7 @@ void UBugsnagFunctionLibrary::SetContext(const FString& Context)
 	{
 		GPlatformBugsnag.SetContext(TOptional<FString>(Context));
 	}
+	bHasCustomContext = true;
 #endif
 }
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -44,7 +44,11 @@ public:
 
 	const TOptional<FString>& GetContext() const { return Context; }
 
-	void SetContext(const TOptional<FString>& Value) { Context = Value; }
+	void SetContext(const TOptional<FString>& Value)
+	{
+		Context = Value;
+		bHasCustomContext = Value.IsSet();
+	}
 
 	// DiscardClasses
 
@@ -245,11 +249,13 @@ private:
 
 	friend class FApplePlatformConfiguration;
 	friend class FAndroidPlatformConfiguration;
+	friend class UBugsnagFunctionLibrary;
 
 	FString ApiKey;
 	bool bAutoDetectErrors = true;
 	bool bAutoTrackSessions = true;
 	TOptional<FString> Context;
+	bool bHasCustomContext = false;
 	TArray<FString> DiscardClasses;
 	EBugsnagEnabledBreadcrumbTypes EnabledBreadcrumbTypes = EBugsnagEnabledBreadcrumbTypes::All;
 	FBugsnagErrorTypes EnabledErrorTypes;

--- a/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
+++ b/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
@@ -4,6 +4,7 @@ static TArray<FString> ScenarioNames = {
 	TEXT("CancelNotifyFromCallback"),
 	TEXT("CancelSessionScenario"),
 	TEXT("CrashAfterLaunchedScenario"),
+	TEXT("CustomContextOpenLevelScenario"),
 	TEXT("GetCrumbScenario"),
 	TEXT("MaxConfigCrashScenario"),
 	TEXT("ModifyCrumbsScenario"),

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/CustomContextOpenLevelScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/CustomContextOpenLevelScenario.cpp
@@ -1,0 +1,34 @@
+#include "Scenario.h"
+
+#include "Kismet/GameplayStatics.h"
+
+//
+// Opens a new level to verify that custom context is not overwritten
+//
+class CustomContextOpenLevelScenario : public Scenario
+{
+public:
+	void Configure() override
+	{
+		Configuration->SetContext(FString(TEXT("game")));
+	}
+
+	void Run() override
+	{
+		UWorld* World = GetCurrentPlayWorld();
+
+		// Will be processed safely on the next tick in UGameEngine::Tick()
+		UGameplayStatics::OpenLevel(World, TEXT("/Game/AnotherWorld"));
+
+		// Using timer to allow OpenLevel() to complete before calling Notify()
+		FTimerHandle TimerHandle;
+		World->GetTimerManager().SetTimer(
+			TimerHandle, []()
+			{
+				UBugsnagFunctionLibrary::Notify(TEXT(""), TEXT(""));
+			},
+			2.f, false);
+	}
+};
+
+REGISTER_SCENARIO(CustomContextOpenLevelScenario);

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -80,9 +80,11 @@ Feature: Reporting handled errors
     And I wait to receive 2 errors
     Then the event "metaData.lastRunInfo" is null
     And the event "app.isLaunching" is false
+    And the event "context" matches "/Game/MainLevel"
     And I discard the oldest error
     And the exception "errorClass" equals "Resolution failed"
     And the exception "message" equals "invalid index (-1)"
+    And the event "context" matches "/Game/MainLevel"
     And the event "metaData.lastRunInfo.crashed" is true
     And the event "metaData.lastRunInfo.crashedDuringLaunch" is false
     And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 0
@@ -115,3 +117,8 @@ Feature: Reporting handled errors
   Scenario: Cancel notify from callback
     When I run "CancelNotifyFromCallback"
     Then I should receive no errors
+
+  Scenario: Custom context is not overwritten by level changes
+    When I run "CustomContextOpenLevelScenario"
+    And I wait to receive an error
+    Then the event "context" equals "game"

--- a/features/support/scenario_names.rb
+++ b/features/support/scenario_names.rb
@@ -4,6 +4,7 @@ $scenario_names = [
   'CancelNotifyFromCallback',
   'CancelSessionScenario',
   'CrashAfterLaunchedScenario',
+  'CustomContextOpenLevelScenario',
   'GetCrumbScenario',
   'MaxConfigCrashScenario',
   'ModifyCrumbsScenario',


### PR DESCRIPTION
## Goal

Automatically set the event `context` to the current level / map.

If a custom context has been provided, it will not be overridden.

## Testing

Amends existing scenario to verify that context is populated automatically.

Adds an E2E scenario to verify that custom context is not overridden upon map change.