### PR TITLE
fix(android): add libUE4.so to automatic upload path

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
+++ b/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
@@ -58,6 +58,7 @@ bugsnag {
     uploadJvmMappings = true
     uploadNdkMappings = true
     reportBuilds = true
+    sharedObjectPaths = [new File("</insert><insertValue value="$S(BuildDir)/jni/$S(Architecture)"/><insert>")]
 }
                 </insert>
             </true>


### PR DESCRIPTION
## Goal

Add the default path for compiled Android libraries to the upload search paths.

## Testing

Tested manually that the correct path is added to uploads