### PR TITLE
Add 'gpu' prefix to adapterName and driverVersion

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
@@ -229,12 +229,12 @@ void FBugsnagConfiguration::AddDefaultMetadata()
 
 	if (!GRHIAdapterName.IsEmpty())
 	{
-		DeviceMetadata->SetStringField(BugsnagConstants::AdapterName, *GRHIAdapterName);
+		DeviceMetadata->SetStringField(BugsnagConstants::GPUAdapterName, *GRHIAdapterName);
 	}
 
 	if (!GRHIAdapterInternalDriverVersion.IsEmpty())
 	{
-		DeviceMetadata->SetStringField(BugsnagConstants::DriverVersion, *GRHIAdapterInternalDriverVersion);
+		DeviceMetadata->SetStringField(BugsnagConstants::GPUDriverVersion, *GRHIAdapterInternalDriverVersion);
 	}
 
 	AddMetadata(BugsnagConstants::Device, DeviceMetadata);

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConstants.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConstants.cpp
@@ -3,10 +3,10 @@
 namespace BugsnagConstants
 {
 const TCHAR* const Activity = TEXT("activity");
-const TCHAR* const AdapterName = TEXT("adapterName");
 const TCHAR* const Device = TEXT("device");
-const TCHAR* const DriverVersion = TEXT("driverVersion");
 const TCHAR* const GameStateName = TEXT("gameStateName");
+const TCHAR* const GPUAdapterName = TEXT("gpuAdapterName");
+const TCHAR* const GPUDriverVersion = TEXT("gpuDriverVersion");
 const TCHAR* const MapUrl = TEXT("mapUrl");
 const TCHAR* const Name = TEXT("name");
 const TCHAR* const UnrealEngine = TEXT("unrealEngine");

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConstants.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConstants.h
@@ -5,10 +5,10 @@
 namespace BugsnagConstants
 {
 extern const TCHAR* const Activity;
-extern const TCHAR* const AdapterName;
 extern const TCHAR* const Device;
-extern const TCHAR* const DriverVersion;
 extern const TCHAR* const GameStateName;
+extern const TCHAR* const GPUAdapterName;
+extern const TCHAR* const GPUDriverVersion;
 extern const TCHAR* const MapUrl;
 extern const TCHAR* const Name;
 extern const TCHAR* const UnrealEngine;

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -49,8 +49,8 @@ Feature: Reporting handled errors
     And the event "metaData.custom.someValue" equals "foobar"
     And the event "metaData.custom.lastValue" is true
     And the event "metaData.custom.notify" equals "testing"
-    And the event "metaData.device.adapterName" is not null
-    And on Android, the event "metaData.device.driverVersion" is not null
+    And the event "metaData.device.gpuAdapterName" is not null
+    And on Android, the event "metaData.device.gpuDriverVersion" is not null
     And on Android, the error payload field "events.0.projectPackages" is an array with 1 elements
     And on Android, the event "projectPackages.0" equals "com.example.package"
     And the event "metaData.unrealEngine.mapUrl" matches "/Game/MainLevel"

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -26,8 +26,8 @@ Feature: Unhandled errors
     And on iOS, the event "metaData.custom.configOnSendError" equals "hello"
     And the event "metaData.custom.someOtherValue" equals "foobar"
     And the event "metaData.custom.someValue" is null
-    And the event "metaData.device.adapterName" is not null
-    And on Android, the event "metaData.device.driverVersion" is not null
+    And the event "metaData.device.gpuAdapterName" is not null
+    And on Android, the event "metaData.device.gpuDriverVersion" is not null
     And the event "metaData.unrealEngine.mapUrl" matches "/Game/MainLevel"
     And the event "metaData.unrealEngine.gameStateName" equals "GameStateBase"
     And the event "metaData.unrealEngine.userActivity" is not null


### PR DESCRIPTION
## Goal

Rename `adapterName` to `gpuAdapterName` and `driverVersion` to `gpuDriverVersion` for clarity.