### PR TITLE
Update bugsnag-cocoa to v6.14.3

### DIFF
--- a/make/Cocoa.make
+++ b/make/Cocoa.make
@@ -2,7 +2,7 @@
 .SUFFIXES:        # remove default suffix rules
 MAKEFLAGS += --no-builtin-rules # skip trying automatic rules (small speedup)
 
-BUGSNAG_COCOA_VERSION?=a93fbb6002727810b7040a48b7a88fc5debed691
+BUGSNAG_COCOA_VERSION?=a0e2c1922c4c45bd7a2ed30c1ffa5194f1cf83ac
 BUGSNAG_COCOA_SRC=deps/bugsnag-cocoa
 BUGSNAG_COCOA_SENTINEL=$(BUGSNAG_COCOA_SRC)/VERSION
 


### PR DESCRIPTION
## Goal

Update to the [6.14.3](https://github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.14.3) release of bugsnag-cocoa that contains all the fixes needed for Unreal Engine.
