### PR TITLE
Make Notify callable from Blueprints again

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagFunctionLibrary.h
@@ -27,7 +27,6 @@ public:
 	// Notify
 
 	// Report an error to Bugsnag.
-	FORCEINLINE
 	UFUNCTION(BlueprintCallable, Category = "Bugsnag")
 	static void Notify(const FString& ErrorClass, const FString& Message)
 	{


### PR DESCRIPTION
## Goal

Fix use of `UBugsnagFunctionLibrary::Notify()` from Blueprints.

## Changeset

Removes the `FORCEINLINE` directive which appears to have broken the parsing of the header.

## Testing

Prior to this change the example app's widget blueprint was showing the following error, which is now fixed:

<img width="1097" alt="Screenshot 2021-11-08 at 14 51 00" src="https://user-images.githubusercontent.com/61777/140764012-bedc188f-360e-4bca-a36f-4adbdf4ef06f.png">

E2E tests verify that the top stack frame is the expected one.

Manually verified that calling the variants of `Notify()` with and without callback result in the same stack trace.