### PR TITLE
Upload plugin builds to BuildKite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,6 +55,7 @@ steps:
     env:
       UE_VERSION: "4.23"
     command: make package
+    artifact_paths: [Build/Plugin/*.zip]
     timeout_in_minutes: 30
 
   - name: 'Build Plugin - UE 4.27'
@@ -63,6 +64,7 @@ steps:
     env:
       UE_VERSION: "4.27"
     command: make package
+    artifact_paths: [Build/Plugin/*.zip]
     timeout_in_minutes: 30
 
   - name: 'Build Plugin - UE 5 EA'
@@ -71,6 +73,7 @@ steps:
     env:
       UE_VERSION: "5.0EA"
     command: make package
+    artifact_paths: [Build/Plugin/*.zip]
     timeout_in_minutes: 30
 
   - name: ':windows: Build Example - UE 4.27'

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ package: ## assemble library for release or testing
 	$(MAKE) -f make/Cocoa.make package
 	"$(UE_RUNUAT)" BuildPlugin \
 		-Plugin="$(PWD)/Plugins/Bugsnag/Bugsnag.uplugin" \
-		-Package="$(PWD)/Build/Package"
+		-Package="$(PWD)/Build/Plugin/Bugsnag"
+	cd "$(PWD)/Build/Plugin" && zip -r Bugsnag-UE$(UE_VERSION).zip Bugsnag
 
 .PHONY: bump
 bump: ## Bump the version numbers to $VERSION


### PR DESCRIPTION
## Goal

Attach a zip file containing the built plugin to each BuildKite build, to make it easier to integrate Bugsnag during testing.

<img width="569" alt="Screenshot 2021-11-09 at 13 36 48" src="https://user-images.githubusercontent.com/61777/140933872-47530462-bafc-49ee-885c-edf03ec5b1b5.png">