### PR TITLE
Load config from Start(ApiKey)

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
@@ -10,7 +10,17 @@
 
 void UBugsnagFunctionLibrary::Start(const FString& ApiKey)
 {
-	Start(MakeShared<FBugsnagConfiguration>(ApiKey));
+	TSharedPtr<FBugsnagConfiguration> Configuration = FBugsnagConfiguration::Load();
+	if (Configuration.IsValid())
+	{
+		Configuration->SetApiKey(ApiKey);
+	}
+	else
+	{
+		UE_LOG(LogBugsnag, Error, TEXT("Could not load configuration from DefaultEngine.ini"));
+		Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
+	}
+	Start(Configuration.ToSharedRef());
 }
 
 static TSharedRef<FJsonObject> MakeJsonObject(const FString& Key, const FString& Value)

--- a/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
+++ b/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
@@ -15,4 +15,5 @@ static TArray<FString> ScenarioNames = {
 	TEXT("OpenLevelBreadcrumbsScenario"),
 	TEXT("PauseSessionScenario"),
 	TEXT("ResumeSessionScenario"),
+	TEXT("StartWithApiKeyScenario"),
 };

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/Scenario.h
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/Scenario.h
@@ -47,14 +47,14 @@ public:
 
 	////////////////////////////////////////////////////////////////////////////
 
+	const FString ApiKey = TEXT("12312312312312312312312312312312");
+	const FString NotifyEndpoint = TEXT("http://bs-local.com:9339/notify");
+	const FString SessionsEndpoint = TEXT("http://bs-local.com:9339/sessions");
+
 	Scenario()
 	{
-		Configuration = new FBugsnagConfiguration(
-			TEXT("12312312312312312312312312312312"));
-
-		Configuration->SetEndpoints(
-			TEXT("http://bs-local.com:9339/notify"),
-			TEXT("http://bs-local.com:9339/sessions"));
+		Configuration = new FBugsnagConfiguration(ApiKey);
+		Configuration->SetEndpoints(NotifyEndpoint, SessionsEndpoint);
 	}
 
 	virtual void Configure()

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/StartWithApiKeyScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/StartWithApiKeyScenario.cpp
@@ -1,0 +1,26 @@
+#include "Scenario.h"
+
+class StartWithApiKeyScenario : public Scenario
+{
+public:
+	void Configure() override
+	{
+		// Modify UBugsnagSettings to simulate options being set in DefaultEngine.ini
+		UBugsnagSettings* Settings = GetMutableDefault<UBugsnagSettings>();
+		Settings->NotifyEndpoint = NotifyEndpoint;
+		Settings->SessionsEndpoint = SessionsEndpoint;
+		Settings->Context = TEXT("FromSettings");
+	}
+
+	void StartBugsnag() override
+	{
+		UBugsnagFunctionLibrary::Start(ApiKey);
+	}
+
+	void Run() override
+	{
+		UBugsnagFunctionLibrary::Notify(TEXT("Game over"), TEXT("You died"));
+	}
+};
+
+REGISTER_SCENARIO(StartWithApiKeyScenario);

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -121,3 +121,8 @@ Feature: Reporting handled errors
     When I run "CustomContextOpenLevelScenario"
     And I wait to receive an error
     Then the event "context" equals "game"
+
+  Scenario: Settings are honored when using Start(ApiKey)
+    When I run "StartWithApiKeyScenario"
+    And I wait to receive an error
+    And the event "context" equals "FromSettings"

--- a/features/support/scenario_names.rb
+++ b/features/support/scenario_names.rb
@@ -15,4 +15,5 @@ $scenario_names = [
   'OpenLevelBreadcrumbsScenario',
   'PauseSessionScenario',
   'ResumeSessionScenario',
+  'StartWithApiKeyScenario',
 ]


### PR DESCRIPTION
## Goal

Use settings defined in `DefaultEngine.ini` when Bugsnag is started via `UBugsnagFunctionLibrary::Start(ApiKey)`

## Testing

Adds e2e test to verify behaviour.