### PR TITLE
[PLAT-7601] Add unrealEngine to runtimeVersions

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.cpp
@@ -10,6 +10,8 @@
 #include "AndroidEvent.h"
 #include "AndroidPlatformConfiguration.h"
 #include "AndroidSession.h"
+#include "BugsnagConstants.h"
+#include "BugsnagUtils.h"
 #include "JNIUtilities.h"
 #include "Shorthand.h"
 
@@ -32,6 +34,13 @@ void FAndroidPlatformBugsnag::Start(const TSharedRef<FBugsnagConfiguration>& Con
 		jobject jConfig = FAndroidPlatformConfiguration::Parse(Env, &JNICache, Config);
 		jobject jClient = (*Env).CallStaticObjectMethod(JNICache.BugsnagClass, JNICache.BugsnagStartMethod, jActivity, jConfig);
 		JNICache.initialized = !FAndroidPlatformJNI::CheckAndClearException(Env) && jClient != NULL;
+		if (JNICache.initialized)
+		{
+			jstring jKey = FAndroidPlatformJNI::ParseFString(Env, BugsnagConstants::UnrealEngine);
+			jstring jValue = FAndroidPlatformJNI::ParseFString(Env, BugsnagUtils::GetUnrealEngineVersion());
+			(*Env).CallVoidMethod(jClient, JNICache.ClientAddRuntimeVersionInfo, jKey, jValue);
+			FAndroidPlatformJNI::CheckAndClearException(Env);
+		}
 	}
 }
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
@@ -65,6 +65,7 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 	CacheExternalJavaClass(env, cache->BreadcrumbClass, "com.bugsnag.android.Breadcrumb");
 	CacheExternalJavaClass(env, cache->BugsnagClass, "com.bugsnag.android.Bugsnag");
 	CacheExternalJavaClass(env, cache->BugsnagUnrealPluginClass, "com.bugsnag.android.unreal.UnrealPlugin");
+	CacheExternalJavaClass(env, cache->ClientClass, "com.bugsnag.android.Client");
 	CacheExternalJavaClass(env, cache->ConfigClass, "com.bugsnag.android.Configuration");
 	CacheExternalJavaClass(env, cache->DeviceClass, "com.bugsnag.android.Device");
 	CacheExternalJavaClass(env, cache->DeviceWithStateClass, "com.bugsnag.android.DeviceWithState");
@@ -159,6 +160,8 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 	CacheStaticJavaMethod(env, cache->MetadataParserParse, cache->MetadataParserClass, "parse", "([B)Ljava/util/Map;");
 
 	CacheStaticJavaMethod(env, cache->MetadataSerializerSerialize, cache->MetadataSerializerClass, "serialize", "(Ljava/util/Map;)[B");
+
+	CacheInstanceJavaMethod(env, cache->ClientAddRuntimeVersionInfo, cache->ClientClass, "addRuntimeVersionInfo", "(Ljava/lang/String;Ljava/lang/String;)V");
 
 	CacheInstanceJavaMethod(env, cache->ConfigConstructor, cache->ConfigClass, "<init>", "(Ljava/lang/String;)V");
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -16,6 +16,7 @@ typedef struct
 	jclass BreadcrumbTypeClass;
 	jclass BugsnagClass;
 	jclass BugsnagUnrealPluginClass;
+	jclass ClientClass;
 	jclass ConfigClass;
 	jclass DeviceClass;
 	jclass DeviceWithStateClass;
@@ -103,6 +104,7 @@ typedef struct
 	jmethodID BugsnagUnrealPluginGetMetadataSection;
 	jmethodID BugsnagUnrealPluginGetMetadataValue;
 	jmethodID BugsnagUnrealPluginNotify;
+	jmethodID ClientAddRuntimeVersionInfo;
 	jmethodID ConfigAddMetadata;
 	jmethodID ConfigAddPlugin;
 	jmethodID ConfigConstructor;

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
@@ -1,10 +1,10 @@
 #include "BugsnagConfiguration.h"
 
 #include "BugsnagConstants.h"
+#include "BugsnagUtils.h"
 
 #include "Engine/Engine.h"
 #include "GameFramework/GameState.h"
-#include "Misc/EngineVersion.h"
 #include "RHI.h"
 #include "UserActivityTracking.h"
 
@@ -229,7 +229,7 @@ void FBugsnagConfiguration::AddDefaultMetadata()
 
 	TSharedRef<FJsonObject> EngineMetadata = MakeShared<FJsonObject>();
 
-	EngineMetadata->SetStringField(BugsnagConstants::Version, FEngineVersion::Current().ToString(EVersionComponent::Changelist));
+	EngineMetadata->SetStringField(BugsnagConstants::Version, BugsnagUtils::GetUnrealEngineVersion());
 
 	UWorld* CurrentPlayWorld = GetCurrentPlayWorld();
 	if (CurrentPlayWorld)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagUtils.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagUtils.cpp
@@ -1,0 +1,8 @@
+#include "BugsnagUtils.h"
+
+#include "Misc/EngineVersion.h"
+
+FString BugsnagUtils::GetUnrealEngineVersion()
+{
+	return FEngineVersion::Current().ToString(EVersionComponent::Changelist);
+}

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagUtils.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagUtils.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+namespace BugsnagUtils
+{
+FString GetUnrealEngineVersion();
+};

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/IOS/ApplePlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/IOS/ApplePlatformBugsnag.cpp
@@ -2,6 +2,8 @@
 
 #include "AppleBugsnagUtils.h"
 #include "ApplePlatformConfiguration.h"
+#include "BugsnagConstants.h"
+#include "BugsnagUtils.h"
 #include "WrappedBreadcrumb.h"
 #include "WrappedEvent.h"
 #include "WrappedSession.h"
@@ -23,7 +25,10 @@ DEFINE_PLATFORM_BUGSNAG(FApplePlatformBugsnag);
 
 void FApplePlatformBugsnag::Start(const TSharedRef<FBugsnagConfiguration>& Configuration)
 {
-	FWrappedMetadataStore::CocoaStore = [Bugsnag startWithConfiguration:FApplePlatformConfiguration::Configuration(Configuration)];
+	BugsnagClient* Client = [Bugsnag startWithConfiguration:FApplePlatformConfiguration::Configuration(Configuration)];
+	[Client addRuntimeVersionInfo:NSStringFromFString(BugsnagUtils::GetUnrealEngineVersion())
+						  withKey:NSStringFromFString(BugsnagConstants::UnrealEngine)];
+	FWrappedMetadataStore::CocoaStore = Client;
 }
 
 void FApplePlatformBugsnag::Notify(

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -34,6 +34,7 @@ Feature: Reporting handled errors
     And the event "device.osVersion" is not null
     And the event "device.runtimeVersions" is not null
     And on Android, the event "device.runtimeVersions.androidApiLevel" is not null
+    And the event "device.runtimeVersions.unrealEngine" is not null
     And the event "device.time" is not null
     And the event "device.totalMemory" is not null
     And the event "metaData.device.batteryLevel" is not null

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -15,6 +15,8 @@ Feature: Unhandled errors
     And the event has a "state" breadcrumb named "Bugsnag loaded"
     And the event has a "manual" breadcrumb named "About to read from a bad memory address"
     And the event "app.isLaunching" is true
+    # TODO: pending on Android (PLAT-7602)
+    And on iOS, the event "device.runtimeVersions.unrealEngine" is not null
     And the event "metaData.pastries.cronut" is false
     And the event "metaData.pastries.macaron" equals 3
     And the event "metaData.counters.forty" equals "40"


### PR DESCRIPTION
## Goal

Add `unrealEngine` to `runtimeVersions` so that we can track the popularity of different engine versions.

This does not yet work for NDK crashes because the persistence layer looks for [hard coded keys](https://github.com/bugsnag/bugsnag-android/blob/next/bugsnag-plugin-android-ndk/src/main/jni/metadata.c#L542-L552).

## Testing

E2E scenarios have been amended to verify the presence of `device.runtimeVersions.unrealEngine`