### PR TITLE
test: add cases for filtering crumbs by type

### DIFF
--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -11,6 +11,22 @@ Feature: Breadcrumbs and modifying with callbacks
     And the event "breadcrumbs.0.metaData.macaron" equals 3
     And the event "breadcrumbs.0.metaData.cronut" is false
 
+  Scenario: Filtering out all automatic breadcrumbs
+    When I run "RestrictAllCrumbTypesScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Unreal Bugsnag Notifier" notifier
+    And the error payload field "events.0.breadcrumbs" is an array with 1 elements
+    And the event "breadcrumbs.0.name" equals "Message in a bottle"
+    And the event "breadcrumbs.0.type" equals "navigation"
+
+  Scenario: Filtering out some automatic breadcrumbs by type
+    When I run "RestrictSomeCrumbTypesScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Unreal Bugsnag Notifier" notifier
+    And the error payload field "events.0.breadcrumbs" is an array with 1 elements
+    And the event "breadcrumbs.0.name" equals "Message in a bottle"
+    And the event "breadcrumbs.0.type" equals "manual"
+
   Scenario: Automatic breadcrumbs for Unreal Engine map changes
     When I run "OpenLevelBreadcrumbsScenario"
     And I wait to receive an error

--- a/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
+++ b/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
@@ -14,6 +14,8 @@ static TArray<FString> ScenarioNames = {
 	TEXT("NotifyWithLaunchInfoScenario"),
 	TEXT("OpenLevelBreadcrumbsScenario"),
 	TEXT("PauseSessionScenario"),
+	TEXT("RestrictAllCrumbTypesScenario"),
+	TEXT("RestrictSomeCrumbTypesScenario"),
 	TEXT("ResumeSessionScenario"),
 	TEXT("StartWithApiKeyScenario"),
 };

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/RestrictAllCrumbTypesScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/RestrictAllCrumbTypesScenario.cpp
@@ -1,0 +1,18 @@
+#include "Scenario.h"
+
+class RestrictAllCrumbTypesScenario : public Scenario
+{
+public:
+	void Configure() override
+	{
+		Configuration->SetEnabledBreadcrumbTypes(EBugsnagEnabledBreadcrumbTypes::Manual);
+	}
+
+	void Run() override
+	{
+		UBugsnagFunctionLibrary::LeaveBreadcrumb(TEXT("Message in a bottle"), EBugsnagBreadcrumbType::Navigation);
+		UBugsnagFunctionLibrary::Notify("Dispatching a crumb", "none");
+	}
+};
+
+REGISTER_SCENARIO(RestrictAllCrumbTypesScenario);

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/RestrictSomeCrumbTypesScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/RestrictSomeCrumbTypesScenario.cpp
@@ -1,0 +1,19 @@
+#include "Scenario.h"
+
+class RestrictSomeCrumbTypesScenario : public Scenario
+{
+public:
+	void Configure() override
+	{
+		// none of these should happen
+		Configuration->SetEnabledBreadcrumbTypes(EBugsnagEnabledBreadcrumbTypes::Navigation | EBugsnagEnabledBreadcrumbTypes::Request);
+	}
+
+	void Run() override
+	{
+		UBugsnagFunctionLibrary::LeaveBreadcrumb(TEXT("Message in a bottle"));
+		UBugsnagFunctionLibrary::Notify("Dispatching a crumb", "none");
+	}
+};
+
+REGISTER_SCENARIO(RestrictSomeCrumbTypesScenario);

--- a/features/support/scenario_names.rb
+++ b/features/support/scenario_names.rb
@@ -14,6 +14,8 @@ $scenario_names = [
   'NotifyWithLaunchInfoScenario',
   'OpenLevelBreadcrumbsScenario',
   'PauseSessionScenario',
+  'RestrictAllCrumbTypesScenario',
+  'RestrictSomeCrumbTypesScenario',
   'ResumeSessionScenario',
   'StartWithApiKeyScenario',
 ]


### PR DESCRIPTION
## Goal

Additional coverage for breadcrumb type logic - ruling out a few reported issues in UAT.

## Testing

* One test case for clearing all enabled breadcrumb types
* One case where some types are enabled, but intentionally not `state` which is the type used for loading Bugsnag and connectivity changes, etc