### PR TITLE
Add builds for UE 4.25 and 4.26 to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,6 +21,7 @@ steps:
       queue: opensource-mac-unreal-4.23
     env:
       UE_VERSION: "4.23"
+      NDKROOT: /Users/administrator/Library/Android/sdk/ndk/16.1.4479499
     command: make package
     artifact_paths: [Build/Plugin/*.zip]
     timeout_in_minutes: 30


### PR DESCRIPTION
## Goal

Add builds for UE 4.25 and 4.26 to CI.  

## Design

4.25 is build by our macOS 10.15 server, 4.26 by macOS 11.

## Changeset

I've also reordered the pipeline so if builds the plugins first - they are much quicker to build so we get some feedback much sooner.

## Testing

Covered by CI.