### PR TITLE
fix(android): use smaller int types for bounded options

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/IOS/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/IOS/Specs/ApplePlatformConfiguration.spec.cpp
@@ -158,7 +158,7 @@ void FApplePlatformConfigurationSpec::Define()
 					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetMaxBreadcrumbs(100);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
-					TEST_EQUAL((int64)CocoaConfig.maxBreadcrumbs, (int64)100);
+					TEST_EQUAL((int32)CocoaConfig.maxBreadcrumbs, (int32)100);
 				});
 
 			It("MaxPersistedEvents", [this]()
@@ -166,7 +166,7 @@ void FApplePlatformConfigurationSpec::Define()
 					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetMaxPersistedEvents(100);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
-					TEST_EQUAL((int64)CocoaConfig.maxPersistedEvents, (int64)100);
+					TEST_EQUAL((int32)CocoaConfig.maxPersistedEvents, (int32)100);
 				});
 
 			It("MaxPersistedSessions", [this]()
@@ -174,7 +174,7 @@ void FApplePlatformConfigurationSpec::Define()
 					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetMaxPersistedSessions(100);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
-					TEST_EQUAL((int64)CocoaConfig.maxPersistedSessions, (int64)100);
+					TEST_EQUAL((int32)CocoaConfig.maxPersistedSessions, (int32)100);
 				});
 
 			It("PersistUser", [this]()

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -117,9 +117,9 @@ public:
 
 	// Max Breadcrumbs
 
-	uint64 GetMaxBreadcrumbs() const { return MaxBreadcrumbs; }
+	uint32 GetMaxBreadcrumbs() const { return MaxBreadcrumbs; }
 
-	void SetMaxBreadcrumbs(uint64 Value)
+	void SetMaxBreadcrumbs(uint32 Value)
 	{
 		if (Value > 100)
 		{
@@ -133,15 +133,15 @@ public:
 
 	// Max Persisted Events
 
-	uint64 GetMaxPersistedEvents() const { return MaxPersistedEvents; }
+	uint32 GetMaxPersistedEvents() const { return MaxPersistedEvents; }
 
-	void SetMaxPersistedEvents(uint64 Value) { MaxPersistedEvents = Value; };
+	void SetMaxPersistedEvents(uint32 Value) { MaxPersistedEvents = Value; };
 
 	// Max Persisted Sessions
 
-	uint64 GetMaxPersistedSessions() const { return MaxPersistedSessions; }
+	uint32 GetMaxPersistedSessions() const { return MaxPersistedSessions; }
 
-	void SetMaxPersistedSessions(uint64 Value) { MaxPersistedSessions = Value; };
+	void SetMaxPersistedSessions(uint32 Value) { MaxPersistedSessions = Value; };
 
 	// Persist User
 
@@ -261,9 +261,9 @@ private:
 	EBugsnagSendThreadsPolicy SendThreads = EBugsnagSendThreadsPolicy::All;
 	uint64 LaunchDurationMillis = 5000;
 	bool bSendLaunchCrashesSynchronously = true;
-	uint64 MaxBreadcrumbs = 50;
-	uint64 MaxPersistedEvents = 32;
-	uint64 MaxPersistedSessions = 128;
+	uint32 MaxBreadcrumbs = 50;
+	uint32 MaxPersistedEvents = 32;
+	uint32 MaxPersistedSessions = 128;
 	bool bPersistUser = true;
 	FBugsnagUser User;
 	TOptional<FString> ReleaseStage;

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagSettings.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagSettings.h
@@ -163,15 +163,15 @@ class BUGSNAG_API UBugsnagSettings : public UObject
 
 	// The maximum number of breadcrumbs to store before deleting the oldest.
 	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Advanced Configuration", Meta = (ClampMax = "100"))
-	uint64 MaxBreadcrumbs = 50;
+	uint32 MaxBreadcrumbs = 50;
 
 	// The maximum number of events to store before deleting the oldest.
 	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Advanced Configuration", Meta = (ClampMin = "1"))
-	uint64 MaxPersistedEvents = 32;
+	uint32 MaxPersistedEvents = 32;
 
 	// The maximum number of sessions to store before deleting the oldest.
 	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Advanced Configuration", Meta = (ClampMin = "1"))
-	uint64 MaxPersistedSessions = 128;
+	uint32 MaxPersistedSessions = 128;
 
 	// Whether User information should be persisted to disk between application runs.
 	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Advanced Configuration")


### PR DESCRIPTION
## Goal

avoid the possibility of passing long long values as ints, especially as bugsnag-android has pending changes and breaking these would be easy.

In the longer term, I want to wrap JNI calls with some rudimentary type safety based on a generated signature file.

## Changeset

* use `uint32` as the type for storage caps in config. Technically we could go smaller, but this matches the underlying implementation types.

## Testing

* Tested manually that the various config options can be set on armv7 and arm64.