### PR TITLE
feat(android): implement onSend

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
+++ b/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
@@ -74,7 +74,7 @@
         <insertNewline/>
         <insert>
             com.bugsnag,bugsnag-plugin-android-unreal,0.1.0
-            com.bugsnag,bugsnag-android,5.15.0
+            com.bugsnag,bugsnag-android,5.16.0
         </insert>
         <insertNewline/>
     </AARImports>

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformBugsnag.h
@@ -66,6 +66,11 @@ public:
 		return RunCallbacks(OnSessionCallbacks, Session);
 	}
 
+	bool RunOnSendCallbacks(TSharedRef<IBugsnagEvent> Event)
+	{
+		return RunCallbacks(OnSendErrorCallbacks, Event);
+	}
+
 private:
 	template <typename T>
 	bool RunCallbacks(TArray<TFunction<bool(TSharedRef<T>)>> Callbacks, TSharedRef<T> CallbackArg)
@@ -82,6 +87,7 @@ private:
 
 	TArray<FBugsnagOnBreadcrumbCallback> OnBreadcrumbCallbacks;
 	TArray<FBugsnagOnSessionCallback> OnSessionCallbacks;
+	TArray<FBugsnagOnErrorCallback> OnSendErrorCallbacks;
 };
 
 DECLARE_PLATFORM_BUGSNAG(FAndroidPlatformBugsnag)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
@@ -159,7 +159,7 @@ jobject FAndroidPlatformConfiguration::Parse(JNIEnv* Env,
 		FAndroidPlatformJNI::CheckAndClearException(Env);
 	}
 
-	jobject jPlugin = (*Env).NewObject(Cache->BugsnagUnrealPluginClass, Cache->BugsnagUnrealPluginConstructor);
+	jobject jPlugin = (*Env).NewObject(Cache->BugsnagUnrealPluginClass, Cache->BugsnagUnrealPluginConstructor, jConfig);
 	ReturnNullOnException(Env);
 	jniCallWithObjects(Env, jConfig, Cache->ConfigAddPlugin, jPlugin);
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
@@ -158,7 +158,7 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 	CacheStaticJavaMethod(env, cache->BugsnagUnrealPluginGetMetadataSection, cache->BugsnagUnrealPluginClass, "getMetadata", "(Ljava/lang/String;)[B");
 	CacheStaticJavaMethod(env, cache->BugsnagUnrealPluginGetMetadataValue, cache->BugsnagUnrealPluginClass, "getMetadata", "(Ljava/lang/String;Ljava/lang/String;)[B");
 	CacheStaticJavaMethod(env, cache->BugsnagUnrealPluginNotify, cache->BugsnagUnrealPluginClass, "notify", "(Ljava/lang/String;Ljava/lang/String;[Ljava/lang/StackTraceElement;Ljava/nio/ByteBuffer;)V");
-	CacheInstanceJavaMethod(env, cache->BugsnagUnrealPluginConstructor, cache->BugsnagUnrealPluginClass, "<init>", "()V");
+	CacheInstanceJavaMethod(env, cache->BugsnagUnrealPluginConstructor, cache->BugsnagUnrealPluginClass, "<init>", "(Lcom/bugsnag/android/Configuration;)V");
 
 	CacheStaticJavaMethod(env, cache->MetadataParserParse, cache->MetadataParserClass, "parse", "([B)Ljava/util/Map;");
 

--- a/deps/bugsnag-plugin-android-unreal/build.gradle
+++ b/deps/bugsnag-plugin-android-unreal/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    api "com.bugsnag:bugsnag-android-core:5.15.0"
+    api "com.bugsnag:bugsnag-android-core:5.16.0"
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'junit:junit:4.12'

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/BadMemoryAccessScenario.cpp
@@ -27,15 +27,6 @@ public:
 		Configuration->AddOnSendError([](TSharedRef<IBugsnagEvent> Event)
 			{
 				Event->AddMetadata(TEXT("custom"), TEXT("configOnSendError"), TEXT("hello"));
-
-				TSharedPtr<FBugsnagLastRunInfo> LastRunInfo = UBugsnagFunctionLibrary::GetLastRunInfo();
-				if (LastRunInfo.IsValid())
-				{
-					Event->AddMetadata(TEXT("lastRunInfo"), TEXT("consecutiveLaunchCrashes"), LastRunInfo->GetConsecutiveLaunchCrashes());
-					Event->AddMetadata(TEXT("lastRunInfo"), TEXT("crashed"), LastRunInfo->GetCrashed());
-					Event->AddMetadata(TEXT("lastRunInfo"), TEXT("crashedDuringLaunch"), LastRunInfo->GetCrashedDuringLaunch());
-				}
-
 				return true;
 			});
 

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/CrashAfterLaunchedScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/CrashAfterLaunchedScenario.cpp
@@ -4,6 +4,22 @@
 class CrashAfterLaunchedScenario : public Scenario
 {
 public:
+	void Configure() override
+	{
+		Configuration->AddOnSendError([](TSharedRef<IBugsnagEvent> Event)
+			{
+				TSharedPtr<FBugsnagLastRunInfo> LastRunInfo = UBugsnagFunctionLibrary::GetLastRunInfo();
+				if (LastRunInfo.IsValid())
+				{
+					Event->AddMetadata(TEXT("lastRunInfo"), TEXT("consecutiveLaunchCrashes"), LastRunInfo->GetConsecutiveLaunchCrashes());
+					Event->AddMetadata(TEXT("lastRunInfo"), TEXT("crashed"), LastRunInfo->GetCrashed());
+					Event->AddMetadata(TEXT("lastRunInfo"), TEXT("crashedDuringLaunch"), LastRunInfo->GetCrashedDuringLaunch());
+				}
+
+				return true;
+			});
+	}
+
 	void Run() override
 	{
 		UBugsnagFunctionLibrary::MarkLaunchCompleted();

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -46,8 +46,7 @@ Feature: Reporting handled errors
     And the event "user.id" equals "1118"
     And the event "user.email" equals "emilie@example.com"
     And the event "user.name" equals "Emilie"
-    # TODO: pending on Android (PLAT-7363, other android changes)
-    And on iOS, the event "metaData.custom.configOnSendError" equals "hello"
+    And the event "metaData.custom.configOnSendError" equals "hello"
     And the event "metaData.custom.someValue" equals "foobar"
     And the event "metaData.custom.lastValue" is true
     And the event "metaData.custom.notify" equals "testing"

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -21,8 +21,7 @@ Feature: Unhandled errors
     And the event "user.id" equals "5402"
     And the event "user.email" equals "usr@example.com"
     And the event "user.name" is null
-    # TODO: pending on Android (PLAT-7363, other android changes)
-    And on iOS, the event "metaData.custom.configOnSendError" equals "hello"
+    And the event "metaData.custom.configOnSendError" equals "hello"
     And the event "metaData.custom.someOtherValue" equals "foobar"
     And the event "metaData.custom.someValue" is null
     And the event "metaData.device.gpuAdapterName" is not null
@@ -31,10 +30,6 @@ Feature: Unhandled errors
     And the event "metaData.unrealEngine.gameStateName" equals "GameStateBase"
     And the event "metaData.unrealEngine.userActivity" is not null
     And the event "metaData.unrealEngine.version" matches "\d\.\d+\.\d+-\d+"
-    # TODO: pending on Android (addition of onSend)
-    And on iOS, the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 1
-    And on iOS, the event "metaData.lastRunInfo.crashed" is true
-    And on iOS, the event "metaData.lastRunInfo.crashedDuringLaunch" is true
     And the method of stack frame 0 is equivalent to "BadMemoryAccessScenario::Run()"
     And the exception "errorClass" equals the platform-dependent string:
       | android | SIGSEGV |
@@ -68,6 +63,9 @@ Feature: Unhandled errors
     Given I run "CrashAfterLaunchedScenario" and restart the crashed app
     And I wait to receive an error
     Then the event "app.isLaunching" is false
+    And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 0
+    And the event "metaData.lastRunInfo.crashed" is true
+    And the event "metaData.lastRunInfo.crashedDuringLaunch" is false
 
   Scenario: Crash with auto detect errors disabled
     Given I run "CrashWithoutAutoDetectionScenario" and restart the crashed app


### PR DESCRIPTION
## Changeset

* Updated to bugsnag-android 5.16.0
* Connected existing hooks for event callbacks

(raising a separate changeset for discard classes)

## Testing

*  Removed a few more TODOs
* Moved lastRunInfo crash assertions into CrashAfterLaunchScenario to avoid calling getLastRunInfo() before the global client is set because launch crashes are sent synchronously, basically making top-level APIs impossible to call in a callback before launch is completed. 🤦 