### PR TITLE
Handle map load failures

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConstants.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConstants.cpp
@@ -21,6 +21,7 @@ namespace BugsnagBreadcrumbMessages
 {
 const TCHAR* const GameStateChanged = TEXT("Game state changed");
 const TCHAR* const MapLoaded = TEXT("Map Loaded");
+const TCHAR* const MapLoadFailed = TEXT("Map Load Failed");
 const TCHAR* const MapLoading = TEXT("Map Loading");
 const TCHAR* const UserActivityChanged = TEXT("User activity changed");
 }; // namespace BugsnagBreadcrumbMessages

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConstants.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConstants.h
@@ -22,6 +22,7 @@ extern const TCHAR* const Version;
 namespace BugsnagBreadcrumbMessages
 {
 extern const TCHAR* const GameStateChanged;
+extern const TCHAR* const MapLoadFailed;
 extern const TCHAR* const MapLoaded;
 extern const TCHAR* const MapLoading;
 extern const TCHAR* const UserActivityChanged;

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -43,6 +43,18 @@ Feature: Breadcrumbs and modifying with callbacks
     And the event "metaData.unrealEngine.gameStateName" matches "AnotherGameState"
     And the event "metaData.unrealEngine.mapUrl" equals "/Game/AnotherWorld"
 
+  Scenario: Automatic breadcrumbs for Unreal Engine map change failures
+    When I run "OpenBadLevelScenario"
+    And I wait to receive an error
+    And the event "breadcrumbs.0.name" equals "Map Loading"
+    And the event "breadcrumbs.0.type" equals "navigation"
+    And the event "breadcrumbs.0.metaData.url" equals "/Game/NonExistant"
+    And the event "breadcrumbs.1.name" equals "Map Load Failed"
+    And the event "breadcrumbs.1.type" equals "navigation"
+    And the event "breadcrumbs.1.metaData.url" equals "/Game/NonExistant"
+    And the event "metaData.unrealEngine.mapUrl" matches "/Game/MainLevel"
+    And the event "metaData.unrealEngine.gameStateName" equals "GameStateBase"
+
   Scenario: Automatic breadcrumbs for Unreal Engine user activity
     When I run "UserActivityBreadcrumbsScenario"
     And I wait to receive an error

--- a/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
+++ b/features/fixtures/mobile/Source/TestFixture/ScenarioNames.h
@@ -16,6 +16,7 @@ static TArray<FString> ScenarioNames = {
 	TEXT("NotifyChangingEverythingInCallback"),
 	TEXT("NotifyScenario"),
 	TEXT("NotifyWithLaunchInfoScenario"),
+	TEXT("OpenBadLevelScenario"),
 	TEXT("OpenLevelBreadcrumbsScenario"),
 	TEXT("PauseSessionScenario"),
 	TEXT("RedactedKeysScenario"),

--- a/features/fixtures/mobile/Source/TestFixture/Scenarios/OpenBadLevelScenario.cpp
+++ b/features/fixtures/mobile/Source/TestFixture/Scenarios/OpenBadLevelScenario.cpp
@@ -1,0 +1,28 @@
+#include "Scenario.h"
+
+#include "Kismet/GameplayStatics.h"
+
+class OpenBadLevelScenario : public Scenario
+{
+public:
+	void Configure() override
+	{
+		Configuration->SetEnabledBreadcrumbTypes(EBugsnagEnabledBreadcrumbTypes::Navigation);
+	}
+
+	void Run() override
+	{
+		// Will be processed safely on the next tick in UGameEngine::Tick()
+		UGameplayStatics::OpenLevel(GetCurrentPlayWorld(), TEXT("/Game/NonExistant"));
+
+		FCoreUObjectDelegates::PostLoadMapWithWorld.AddLambda([](UWorld* World)
+			{
+				if (!World)
+				{
+					UBugsnagFunctionLibrary::Notify(TEXT("LoadMapFailed"), TEXT("Intentionally blank"));
+				}
+			});
+	}
+};
+
+REGISTER_SCENARIO(OpenBadLevelScenario);

--- a/features/support/scenario_names.rb
+++ b/features/support/scenario_names.rb
@@ -16,6 +16,7 @@ $scenario_names = [
   'NotifyChangingEverythingInCallback',
   'NotifyScenario',
   'NotifyWithLaunchInfoScenario',
+  'OpenBadLevelScenario',
   'OpenLevelBreadcrumbsScenario',
   'PauseSessionScenario',
   'RedactedKeysScenario',


### PR DESCRIPTION
## Goal

Fix an unchecked null pointer crash that would occur when map loading fails (found during manual testing.)

## Changeset

Checks for a null `UWorld` in Bugsnag's `PostLoadMapWithWorld` lamdba - this is how `UEngine::LoadMap()` signals failure.

Leaves a new "Map load failed" breadcrumb if `UWorld` is null.

## Testing

Created an e2e scenario to reproduce the crash and verify the fix.