### PR TITLE
Move lint step back to GH Actions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,12 +4,6 @@ env:
 
 steps:
 
-  - name: 'Lint'
-    agents:
-      queue: opensource-mac-cocoa-11
-    command: make lint
-    timeout_in_minutes: 10
-
   ##############################################################################
   #
   # Build Plugin

--- a/.cspell.json
+++ b/.cspell.json
@@ -17,6 +17,7 @@
         "UFUNCTION",
         "UPROPERTY",
         "USTRUCT",
+        "checkf",
         "clazz",
         "cronut",
         "jboolean",

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: "Lint"
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: clang-format
+        run: find Source Plugins/Bugsnag/Source/Bugsnag features/fixtures/mobile/Source -name '*.h' -o -name '*.cpp' | xargs /usr/bin/clang-format-12 --dry-run --Werror
+      - name: cspell
+        run: npm install -g cspell && cspell **/*.{cpp,h}


### PR DESCRIPTION
Moves lint step back to GitHub Actions so that we can use known version (12) of clang-format.

This reverts commit 94878424568b661ecd007f5c5284ac2113bc9104.