### PR TITLE
[PLAT-7903] Improve in-Editor behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ clean: ## remove build artifacts
 editor: $(EXAMPLE_MAC_LIB) ## Build the project and open in Unreal Editor
 	"$(UE_EDITOR)" "$(UPROJECT)"
 
+.PHONY: run
+run: $(EXAMPLE_MAC_LIB) ## Build the example project and run in Unreal Editor's -game mode
+	"$(UE_EDITOR)" "$(UPROJECT)" -game
+
 .PHONY: format
 format: ## format all c/c++ source to match .clang-format
 	find Source Plugins/Bugsnag/Source/Bugsnag features/fixtures/generic/Source -name '*.h' -o -name '*.cpp' | xargs clang-format -i

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
@@ -27,7 +27,19 @@ DEFINE_PLATFORM_BUGSNAG(FApplePlatformBugsnag);
 
 void FApplePlatformBugsnag::Start(const TSharedRef<FBugsnagConfiguration>& Configuration)
 {
-	BugsnagClient* Client = [Bugsnag startWithConfiguration:FApplePlatformConfiguration::Configuration(Configuration)];
+	BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
+#if UE_EDITOR
+	if (!FApp::IsGame())
+	{
+		UE_LOG(LogBugsnag, Log, TEXT("App hang detection is disabled in the Editor"));
+		CocoaConfig.enabledErrorTypes.appHangs = NO;
+	}
+	else
+	{
+		// The Editor may have been launched in game mode, e.g. `UE4Editor <uproject> -game`
+	}
+#endif
+	BugsnagClient* Client = [Bugsnag startWithConfiguration:CocoaConfig];
 	[Client addRuntimeVersionInfo:NSStringFromFString(BugsnagUtils::GetUnrealEngineVersion())
 						  withKey:NSStringFromFString(BugsnagConstants::UnrealEngine)];
 	FWrappedMetadataStore::CocoaStore = Client;

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagFunctionLibrary.cpp
@@ -60,6 +60,19 @@ static void GameStateChanged(const FString& InGameStateName)
 void UBugsnagFunctionLibrary::Start(const TSharedRef<FBugsnagConfiguration>& Configuration)
 {
 #if PLATFORM_IMPLEMENTS_BUGSNAG
+
+#if UE_EDITOR
+	if (!FApp::IsGame())
+	{
+		UE_LOG(LogBugsnag, Log, TEXT("Automatic session tracking is disabled in the Editor"));
+		Configuration->SetAutoTrackSessions(false);
+	}
+	else
+	{
+		// The Editor may have been launched in game mode, e.g. `UE4Editor <uproject> -game`
+	}
+#endif
+
 	GPlatformBugsnag.Start(Configuration);
 
 	static FString MapUrl;


### PR DESCRIPTION
## Goal

Now that Bugsnag functionality is enabled for macOS, opening a project in Unreal Editor will also start Bugsnag in that process.

The aim of this PR is to avoid sending spurious errors and sessions.

## Changeset

1. Ignores crashes that occur in the Editor outside of a PIE session, to avoid sending non-game related crashes to the dashboard. This records the state of `GIsPlayInEditorWorld` at crash time to determine whether the game was being played. Note that crashes that were caused by game code but occurred after play ended (e.g. if there some delay before the crash happening) will be ignored.

2. Disables automatic session tracking in the Editor, to avoid skewing session stability scores.

3. Disables app hang detection in the Editor, since any hangs are likely to be caused by the Editor whose UI regularly becomes unresponsive when starting builds etc.

~4. Disables the "Start Automatically" functionality if `GIsBuildMachine` indicates running in a build machine process.~

Implementation notes:
* `UE_EDITOR` is `1` when building for the Editor
* `GIsEditor` is `false` when the Editor is running a game using the `-game` command line switch
* `GIsPlayInEditorWorld` is set to true when the Editor starts playing a game in-process (i.e. with the Play button)

## Testing

Tested locally by running sample project in Editor, `-game` mode and stand-alone build while examining logs and network requests.