### PR TITLE
[PLAT-7957] Fix reported release stage for iOS & Mac

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
@@ -104,13 +104,7 @@ jobject FAndroidPlatformConfiguration::Parse(JNIEnv* Env,
 	{
 		jniCallWithString(Env, jConfig, Cache->ConfigSetReleaseStage, Config->GetReleaseStage().GetValue());
 	}
-	else
-	{
-		// explicitly set production for shipping builds, otherwise use bugsnag-android default detection
-#if UE_BUILD_SHIPPING
-		jniCallWithString(Env, jConfig, Cache->ConfigSetReleaseStage, FString(TEXT("production")));
-#endif
-	}
+
 	jniCallWithBool(Env, jConfig, Cache->ConfigSetSendLaunchCrashesSynchronously, Config->GetSendLaunchCrashesSynchronously());
 	jobject jThreadPolicy = FAndroidPlatformJNI::ParseThreadSendPolicy(Env, Cache, Config->GetSendThreads());
 	ReturnNullOnFail(jThreadPolicy);

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
@@ -38,7 +38,7 @@ uint64 const FBugsnagConfiguration::AppHangThresholdFatalOnly = INT_MAX;
 FBugsnagConfiguration::FBugsnagConfiguration(const FString& ApiKey)
 {
 	SetApiKey(ApiKey);
-	AddDefaultMetadata();
+	AddDefaults();
 }
 
 FBugsnagConfiguration::FBugsnagConfiguration(const UBugsnagSettings& Settings)
@@ -68,7 +68,7 @@ FBugsnagConfiguration::FBugsnagConfiguration(const UBugsnagSettings& Settings)
 		SetApiKey(Settings.ApiKey);
 	}
 	SetMaxBreadcrumbs(Settings.MaxBreadcrumbs);
-	AddDefaultMetadata();
+	AddDefaults();
 }
 
 TSharedPtr<FBugsnagConfiguration> FBugsnagConfiguration::Load()
@@ -235,8 +235,17 @@ static UWorld* GetCurrentPlayWorld()
 	return nullptr;
 }
 
-void FBugsnagConfiguration::AddDefaultMetadata()
+void FBugsnagConfiguration::AddDefaults()
 {
+	if (!ReleaseStage.IsSet())
+	{
+#if UE_BUILD_SHIPPING
+		ReleaseStage = TEXT("production");
+#else
+		ReleaseStage = TEXT("development");
+#endif
+	}
+
 	TSharedRef<FJsonObject> DeviceMetadata = MakeShared<FJsonObject>();
 
 	if (!GRHIAdapterName.IsEmpty())

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -503,7 +503,7 @@ public:
 private:
 	FBugsnagConfiguration(const UBugsnagSettings& Settings);
 
-	void AddDefaultMetadata();
+	void AddDefaults();
 
 	friend class FApplePlatformConfiguration;
 	friend class FAndroidPlatformConfiguration;

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagSettings.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagSettings.h
@@ -193,7 +193,7 @@ class BUGSNAG_API UBugsnagSettings : public UObject
 	///////////////////////////////////////////////////////////////////////////
 
 	// The release stage of the application, such as production, development, beta et cetera.
-	// Defaults to "development" for debug builds and "production" otherwise.
+	// If empty, "production" will be used for shipping and "development" for other builds.
 	UPROPERTY(GlobalConfig, EditAnywhere, Category = "App Information")
 	FString ReleaseStage;
 


### PR DESCRIPTION
## Goal

`bugsnag-cocoa`'s automatic release stage detection is based on the `DEBUG` compiler macro. This does not work for Unreal Engine games because we always prebuild `bugsnag-cocoa` in release mode, so the release stage was always being reported as `"production"`.

## Changeset

`FBugsnagConfiguration` now controls the automatic release stage, setting it to production for Shipping builds.

## Testing

Tested manually to ensure `"development"` is sent for non-shipping builds.

E2E scenarios verify that `"production"` is sent by default (the fixture is built Shipping configuration) and that manually specifying a release stage overrides this.