### PR TITLE
Move the UE 4.23/4.25/5.0EA steps to a new build queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,6 +28,7 @@ steps:
     env:
       UE_VERSION: "4.23"
       NDKROOT: /Users/administrator/Library/Android/sdk/ndk/16.1.4479499
+      DEVELOPER_DIR: "/Applications/Xcode11.app"
     commands:
       - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
       - make package

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,7 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
     commands:
       - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
       - make package
@@ -45,6 +46,7 @@ steps:
       queue: ms-mac-10-15-6
     env:
       UE_VERSION: "4.25"
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
     commands:
       - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
       - make package
@@ -61,6 +63,7 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.26"
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
     commands:
       - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
       - make package
@@ -77,6 +80,7 @@ steps:
       queue: ms-mac-10-15-6
     env:
       UE_VERSION: "5.0EA"
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
     commands:
       - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
       - make package
@@ -108,6 +112,7 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip
@@ -127,6 +132,7 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip
@@ -146,6 +152,7 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,7 +73,7 @@ steps:
   - name: 'Build Plugin - UE 5 EA'
     if: build.branch =~ /main|next|^release|^integration/ || build.message =~ /\[full ci\]/
     agents:
-      queue: opensource-mac-unreal-5
+      queue: ms-mac-10-15-6
     env:
       UE_VERSION: "5.0EA"
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
-      DEVELOPER_DIR: "/Applications/Xcode12.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.app"
     commands:
       - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
       - make package
@@ -63,7 +63,7 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.26"
-      DEVELOPER_DIR: "/Applications/Xcode12.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.app"
     commands:
       - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
       - make package
@@ -112,7 +112,7 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
-      DEVELOPER_DIR: "/Applications/Xcode12.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip
@@ -132,7 +132,7 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
-      DEVELOPER_DIR: "/Applications/Xcode12.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip
@@ -152,7 +152,7 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
-      DEVELOPER_DIR: "/Applications/Xcode12.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
 
   - name: 'Build Plugin - UE 4.23'
     agents:
-      queue: ms-mac-10-15-6
+      queue: opensource-mac-cocoa-10.15
     env:
       UE_VERSION: "4.23"
       NDKROOT: /Users/administrator/Library/Android/sdk/ndk/16.1.4479499
@@ -43,7 +43,7 @@ steps:
   - name: 'Build Plugin - UE 4.25'
     if: build.branch =~ /main|next|^release|^integration/ || build.message =~ /\[full ci\]/
     agents:
-      queue: ms-mac-10-15-6
+      queue: opensource-mac-cocoa-10.15
     env:
       UE_VERSION: "4.25"
       DEVELOPER_DIR: "/Applications/Xcode12.app"
@@ -77,7 +77,7 @@ steps:
   - name: 'Build Plugin - UE 5 EA'
     if: build.branch =~ /main|next|^release|^integration/ || build.message =~ /\[full ci\]/
     agents:
-      queue: ms-mac-10-15-6
+      queue: opensource-mac-cocoa-10.15
     env:
       UE_VERSION: "5.0EA"
       DEVELOPER_DIR: "/Applications/Xcode12.app"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
 
   - name: 'Build Plugin - UE 4.23'
     agents:
-      queue: opensource-mac-unreal-4.23
+      queue: ms-mac-10-15-6
     env:
       UE_VERSION: "4.23"
       NDKROOT: /Users/administrator/Library/Android/sdk/ndk/16.1.4479499
@@ -41,7 +41,7 @@ steps:
   - name: 'Build Plugin - UE 4.25'
     if: build.branch =~ /main|next|^release|^integration/ || build.message =~ /\[full ci\]/
     agents:
-      queue: opensource-mac-unreal-4.25
+      queue: ms-mac-10-15-6
     env:
       UE_VERSION: "4.25"
     commands:


### PR DESCRIPTION
## Goal

Move the Unreal Engine 4.23/4.25/5.0EA steps to the new macos 10.15 queue

## Changeset

Move the Unreal Engine 4.23/4.25/5.0EA steps to the new macos 10.15 queue

## Testing

Full CI run [here](https://buildkite.com/bugsnag/bugsnag-unreal/builds/753)