### PR TITLE
[PLAT-8190] Add Config.MaxReportedThreads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## TBD
 
+* Adds the `MaxReportedThreads` configuration property (Android only.)
+  [#144](https://github.com/bugsnag/bugsnag-unreal/pull/144)
 * Updates the bugsnag-android dependency from v5.19.2 to [v5.22.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5220-2022-03-31)
 * Updates the bugsnag-cocoa dependency from v6.16.1 to [v6.16.6](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6166-2022-04-06)
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
@@ -89,6 +89,7 @@ jobject FAndroidPlatformConfiguration::Parse(JNIEnv* Env,
 	jniCallWithObjects(Env, jConfig, Cache->ConfigSetMaxBreadcrumbs, Config->GetMaxBreadcrumbs());
 	jniCallWithObjects(Env, jConfig, Cache->ConfigSetMaxPersistedEvents, Config->GetMaxPersistedEvents());
 	jniCallWithObjects(Env, jConfig, Cache->ConfigSetMaxPersistedSessions, Config->GetMaxPersistedSessions());
+	jniCallWithObjects(Env, jConfig, Cache->ConfigSetMaxReportedThreads, Config->GetMaxReportedThreads());
 	jniCallWithBool(Env, jConfig, Cache->ConfigSetPersistUser, Config->GetPersistUser());
 	if (Config->GetRedactedKeys().Num())
 	{

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
@@ -192,6 +192,7 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 	CacheInstanceJavaMethod(env, cache->ConfigSetMaxBreadcrumbs, cache->ConfigClass, "setMaxBreadcrumbs", "(I)V");
 	CacheInstanceJavaMethod(env, cache->ConfigSetMaxPersistedEvents, cache->ConfigClass, "setMaxPersistedEvents", "(I)V");
 	CacheInstanceJavaMethod(env, cache->ConfigSetMaxPersistedSessions, cache->ConfigClass, "setMaxPersistedSessions", "(I)V");
+	CacheInstanceJavaMethod(env, cache->ConfigSetMaxReportedThreads, cache->ConfigClass, "setMaxReportedThreads", "(I)V");
 	CacheInstanceJavaMethod(env, cache->ConfigSetPersistenceDirectory, cache->ConfigClass, "setPersistenceDirectory", "(Ljava/io/File;)V");
 	CacheInstanceJavaMethod(env, cache->ConfigSetPersistUser, cache->ConfigClass, "setPersistUser", "(Z)V");
 	CacheInstanceJavaMethod(env, cache->ConfigSetProjectPackages, cache->ConfigClass, "setProjectPackages", "(Ljava/util/Set;)V");

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -133,6 +133,7 @@ typedef struct
 	jmethodID ConfigSetMaxBreadcrumbs;
 	jmethodID ConfigSetMaxPersistedEvents;
 	jmethodID ConfigSetMaxPersistedSessions;
+	jmethodID ConfigSetMaxReportedThreads;
 	jmethodID ConfigSetPersistenceDirectory;
 	jmethodID ConfigSetPersistUser;
 	jmethodID ConfigSetProjectPackages;

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -273,6 +273,20 @@ public:
 	void SetMaxPersistedSessions(uint32 Value) { MaxPersistedSessions = Value; };
 
 	/**
+	 * The maximum number of Android JVM threads that will be reported with an event.
+	 *
+	 * Once the threshold is reached, all remaining threads will be omitted.
+	 *
+	 * By default, up to 200 threads are reported.
+	 */
+	uint32 GetMaxReportedThreads() const { return MaxReportedThreads; }
+
+	/**
+	 * @param Value The maximum number of threads.
+	 */
+	void SetMaxReportedThreads(uint32 Value) { MaxReportedThreads = Value; }
+
+	/**
 	 * Whether User information should be persisted to disk between application runs.
 	 *
 	 * Defaults to true.
@@ -557,6 +571,7 @@ private:
 	uint32 MaxBreadcrumbs = 50;
 	uint32 MaxPersistedEvents = 32;
 	uint32 MaxPersistedSessions = 128;
+	uint32 MaxReportedThreads = 200;
 	bool bPersistUser = true;
 	FBugsnagUser User;
 	TOptional<FString> ReleaseStage;

--- a/features/fixtures/generic/Source/TestFixture/Scenarios/NotifyScenario.cpp
+++ b/features/fixtures/generic/Source/TestFixture/Scenarios/NotifyScenario.cpp
@@ -42,6 +42,8 @@ public:
 				return true;
 			});
 
+		Configuration->SetMaxReportedThreads(3);
+
 		// sent in event payload
 		Configuration->SetProjectPackages({TEXT("com.example.package")});
 	}

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -5,6 +5,7 @@ Feature: Reporting handled errors
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Unreal Bugsnag Notifier" notifier
     And the error payload field "events.0.threads" is a non-empty array
+    And on Android, the error payload field "events.0.threads" is an array with 4 elements
     And the error payload field "notifier.dependencies.0.name" is not null
     And the error payload field "notifier.dependencies.0.url" is not null
     And the error payload field "notifier.dependencies.0.version" is not null


### PR DESCRIPTION
## Goal

Make the `MaxReportedThreads` property available for configuration.

## Changeset

Adds `GetMaxReportedThreads()` and `SetMaxReportedThreads()` and passes the value on to the Android notifier when starting.

## Testing

Amends existing scenario to verify thread limit takes effect.