### PR TITLE
Move Android build step off of ARM machines

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -224,7 +224,7 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: 'E2E Tests - 5.0 macOS 10.15'
+  - label: 'E2E Tests - 5.0 macOS 12'
     depends_on: mac_fixture_5_0
     timeout_in_minutes: 10
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -57,10 +57,10 @@ steps:
   - name: ':android: Build E2E - 4.27 Android'
     depends_on: plugin_4_27
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: opensource-mac-cocoa-10.15
     env:
       UE_VERSION: "4.27"
-      DEVELOPER_DIR: "/Applications/Xcode13.app"
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip


### PR DESCRIPTION
## Goal

Move the Android build steps off of the ARM machines to reduce the flakeyness of those steps.

## Testing
Covered by a Full CI