### PR TITLE
Move Android fixture build to ARM

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: macos-12-arm
+
 steps:
   #
   # Build Plugins
@@ -23,8 +26,6 @@ steps:
 
   # UE 4.26
   - label: 'Build Plugin - 4.26 Mac'
-    agents:
-      queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.26"
       DEVELOPER_DIR: "/Applications/Xcode13.app"
@@ -41,8 +42,6 @@ steps:
 
   # UE 5.0
   - label: 'Build Plugin - 5.0 Mac'
-    agents:
-      queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "5.0"
       DEVELOPER_DIR: "/Applications/Xcode13.app"
@@ -64,8 +63,6 @@ steps:
   # UE 5.0EA
   - name: ':android: Build E2E - 5.0 Android'
     depends_on: plugin_5_0
-    agents:
-      queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "5.0"
       DEVELOPER_DIR: "/Applications/Xcode13.app"
@@ -84,8 +81,6 @@ steps:
 
   - name: ':ios: Build E2E - 5.0 iOS'
     depends_on: plugin_5_0
-    agents:
-      queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "5.0"
       DEVELOPER_DIR: "/Applications/Xcode13.app"
@@ -104,8 +99,6 @@ steps:
 
   - name: ':mac: Build E2E - 5.0 Mac'
     depends_on: plugin_5_0
-    agents:
-      queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "5.0"
       DEVELOPER_DIR: "/Applications/Xcode13.app"
@@ -209,8 +202,6 @@ steps:
   - label: 'E2E Tests - 5.0 macOS 12'
     depends_on: mac_fixture_5_0
     timeout_in_minutes: 10
-    agents:
-      queue: opensource-arm-mac-cocoa-12
     plugins:
       artifacts#v1.5.0:
         download:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: macos-12-arm
+
 steps:
   #
   # Build Plugins
@@ -24,8 +27,6 @@ steps:
 
   # UE 4.27
   - label: 'Build Plugin - 4.27 Mac'
-    agents:
-      queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
       DEVELOPER_DIR: "/Applications/Xcode13.app"
@@ -56,11 +57,9 @@ steps:
   # UE 4.27
   - name: ':android: Build E2E - 4.27 Android'
     depends_on: plugin_4_27
-    agents:
-      queue: opensource-mac-cocoa-10.15
     env:
       UE_VERSION: "4.27"
-      DEVELOPER_DIR: "/Applications/Xcode12.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip
@@ -76,8 +75,6 @@ steps:
 
   - name: ':ios: Build E2E - 4.27 iOS'
     depends_on: plugin_4_27
-    agents:
-      queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
       DEVELOPER_DIR: "/Applications/Xcode13.app"
@@ -96,8 +93,6 @@ steps:
 
   - name: ':mac: Build E2E - 4.27 Mac'
     depends_on: plugin_4_27
-    agents:
-      queue: opensource-arm-mac-cocoa-12
     env:
       UE_VERSION: "4.27"
       DEVELOPER_DIR: "/Applications/Xcode13.app"
@@ -174,8 +169,6 @@ steps:
   - label: 'E2E Tests - 4.27 macOS 12'
     depends_on: mac_fixture_4_27
     timeout_in_minutes: 10
-    agents:
-      queue: opensource-arm-mac-cocoa-12
     plugins:
       artifacts#v1.5.0:
         download:


### PR DESCRIPTION
## Goal

Move the Android test fixture build back to ARM now that the JDK is stable.

## Changeset

- Default pipeline to use the `macos-12-arm` queue
- Bump the XCode version so it runs on macOS 12.

## Testing

Covered by a full CI run.