### PR TITLE
Fix improper use of TCHAR_TO_UTF8

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.cpp
@@ -376,17 +376,12 @@ bool FAndroidPlatformJNI::LoadReferenceCache(JNIEnv* env, JNIReferenceCache* cac
 
 jstring FAndroidPlatformJNI::ParseFString(JNIEnv* Env, const FString& Text)
 {
-	const char* rawText = TCHAR_TO_UTF8(*Text);
-	if (rawText)
+	jstring jText = (*Env).NewStringUTF(TCHAR_TO_UTF8(*Text));
+	if (FAndroidPlatformJNI::CheckAndClearException(Env))
 	{
-		jstring jText = (*Env).NewStringUTF(rawText);
-		if (FAndroidPlatformJNI::CheckAndClearException(Env))
-		{
-			return NULL;
-		}
-		return jText;
+		return NULL;
 	}
-	return NULL;
+	return jText;
 }
 
 FString FAndroidPlatformJNI::ParseJavaString(JNIEnv* Env, const JNIReferenceCache* Cache, jobject Value)


### PR DESCRIPTION
## Goal

Fix a use-after-free crash in `FAndroidPlatformJNI::ParseFString()` when passed a large string, due to improper use of `TCHAR_TO_UTF8()`.

[StringConv.h](https://github.com/EpicGames/UnrealEngine/blob/4.27.2-release/Engine/Source/Runtime/Core/Public/Containers/StringConv.h#L1165-L1180) states that results should not be captured in a variable:

```
/**
 * NOTE: The objects these macros declare have very short lifetimes. They are
 * meant to be used as parameters to functions. You cannot assign a variable
 * to the contents of the converted string as the object will go out of
 * scope and the string released.
 *
 * NOTE: The parameter you pass in MUST be a proper string, as the parameter
 * is typecast to a pointer. If you pass in a char, not char* it will compile
 * and then crash at runtime.
 *
 * Usage:
 *
 *		SomeApi(TCHAR_TO_ANSI(SomeUnicodeString));
 *
 *		const char* SomePointer = TCHAR_TO_ANSI(SomeUnicodeString); <--- Bad!!!
 */
```

UE's string conversion use [different allocation strategies](https://github.com/EpicGames/UnrealEngine/blob/4.27.2-release/Engine/Source/Runtime/Core/Public/Containers/ContainerAllocationPolicies.h#L678-L682) depending on the size of the data, switching at [128 bytes](https://github.com/EpicGames/UnrealEngine/blob/4.27.2-release/Engine/Source/Runtime/Core/Public/Containers/StringConv.h#L14).

## Changeset

Uses `TCHAR_TO_UTF8()` in the recommended way - as a parameter to `NewStringUTF()`

There is no need for a null check since, given a non-null pointer (which `FString::operator*()` [returns](https://github.com/EpicGames/UnrealEngine/blob/4.27.2-release/Engine/Source/Runtime/Core/Public/Containers/UnrealString.h#L444-L447)), `TCHAR_TO_ANSI()` will also [return a non-null pointer](https://github.com/EpicGames/UnrealEngine/blob/4.27.2-release/Engine/Source/Runtime/Core/Public/Containers/StringConv.h#L1002-L1034).

## Testing

Was unable to reproduce a crash, even when testing with large strings of over 128 bytes.