### PR TITLE
Pin UE 4.26/27 builds to Xcode 13.2.1

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -28,7 +28,7 @@ steps:
   - label: 'Build Plugin - 4.26 Mac'
     env:
       UE_VERSION: "4.26"
-      DEVELOPER_DIR: "/Applications/Xcode13.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.2.1.app"
     commands:
       - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
       - make package
@@ -60,7 +60,7 @@ steps:
   # Build Test Fixtures
   #
 
-  # UE 5.0EA
+  # UE 5.0
   - name: ':android: Build E2E - 5.0 Android'
     depends_on: plugin_5_0
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
   - label: 'Build Plugin - 4.27 Mac'
     env:
       UE_VERSION: "4.27"
-      DEVELOPER_DIR: "/Applications/Xcode13.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.2.1.app"
     commands:
       - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
       - make package
@@ -59,7 +59,7 @@ steps:
     depends_on: plugin_4_27
     env:
       UE_VERSION: "4.27"
-      DEVELOPER_DIR: "/Applications/Xcode13.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.2.1.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip
@@ -77,7 +77,7 @@ steps:
     depends_on: plugin_4_27
     env:
       UE_VERSION: "4.27"
-      DEVELOPER_DIR: "/Applications/Xcode13.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.2.1.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip
@@ -95,7 +95,7 @@ steps:
     depends_on: plugin_4_27
     env:
       UE_VERSION: "4.27"
-      DEVELOPER_DIR: "/Applications/Xcode13.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.2.1.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_4.27-macOS.zip


### PR DESCRIPTION
## Goal

Pin UE 4.26/27 builds to Xcode 13.2.1.

## Design

Newer versions of Xcode break the builds (somewhere between 13.2.1 and 13.4).

## Testing

Covered by a `[full ci]` run.