### PR TITLE
Pin all Xcode13 builds

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -44,7 +44,7 @@ steps:
   - label: 'Build Plugin - 5.0 Mac'
     env:
       UE_VERSION: "5.0"
-      DEVELOPER_DIR: "/Applications/Xcode13.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.2.1.app"
     commands:
       - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
       - make package
@@ -65,7 +65,7 @@ steps:
     depends_on: plugin_5_0
     env:
       UE_VERSION: "5.0"
-      DEVELOPER_DIR: "/Applications/Xcode13.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.2.1.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_5.0-macOS.zip
@@ -83,7 +83,7 @@ steps:
     depends_on: plugin_5_0
     env:
       UE_VERSION: "5.0"
-      DEVELOPER_DIR: "/Applications/Xcode13.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.2.1.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_5.0-macOS.zip
@@ -101,7 +101,7 @@ steps:
     depends_on: plugin_5_0
     env:
       UE_VERSION: "5.0"
-      DEVELOPER_DIR: "/Applications/Xcode13.app"
+      DEVELOPER_DIR: "/Applications/Xcode13.2.1.app"
     plugins:
       artifacts#v1.5.0:
         download: Build/Plugin/Bugsnag-*-UE_5.0-macOS.zip

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -21,7 +21,7 @@ steps:
         upload:
           - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
     artifact_paths: [Build/Plugin/*.zip]
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     key: plugin_4_25
 
   # UE 4.26
@@ -37,7 +37,7 @@ steps:
         upload:
           - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
     artifact_paths: [Build/Plugin/*.zip]
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     key: plugin_4_26
 
   # UE 5.0
@@ -53,7 +53,7 @@ steps:
         upload:
           - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
     artifact_paths: [Build/Plugin/*.zip]
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     key: plugin_5_0
 
   #

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,7 @@ steps:
         upload:
           - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
     artifact_paths: [Build/Plugin/*.zip]
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     key: plugin_4_23
 
   # UE 4.27
@@ -38,7 +38,7 @@ steps:
         upload:
           - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
     artifact_paths: [Build/Plugin/*.zip]
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     key: plugin_4_27
 
   - label: 'Build Plugin - 4.27 Win'
@@ -48,7 +48,7 @@ steps:
       UE_VERSION: "4.27"
     command: build.bat
     artifact_paths: [Bugsnag-*.zip]
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
 
   #
   # Build Test Fixtures


### PR DESCRIPTION
## Goal

Pin all Xcode13 builds to a specific version, avoiding the use of symlinks.

## Design

We've had very slow/unreliable builds when targeting the XCode 13 symlink (which has just change from 13.2.1 to 13.4 on the build servers).  

## Testing

Covered by a full CI run.