### PR TITLE
Bump bugsnag-android to v5.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ## TBD
 
-* Updates the bugsnag-android dependency from v5.22.1 to [v5.22.4](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5224-2022-05-24)
+* Updates the bugsnag-android dependency from v5.22.1 to [v5.23.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5230-2022-06-20)
 
 ## 1.4.0 (2022-05-11)
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
+++ b/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
@@ -74,7 +74,7 @@
         <insertNewline/>
         <insert>
             com.bugsnag,bugsnag-plugin-android-unreal,1.4.0
-            com.bugsnag,bugsnag-android,5.22.4
+            com.bugsnag,bugsnag-android,5.23.0
         </insert>
         <insertNewline/>
     </AARImports>

--- a/deps/bugsnag-plugin-android-unreal/build.gradle
+++ b/deps/bugsnag-plugin-android-unreal/build.gradle
@@ -28,7 +28,7 @@ android {
 }
 
 dependencies {
-    api "com.bugsnag:bugsnag-android-core:5.22.4"
+    api "com.bugsnag:bugsnag-android-core:5.23.0"
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'junit:junit:4.12'


### PR DESCRIPTION
## Goal

Bump bugsnag-android dependency to v5.23.0

Note - this includes a new configuration option that needs to be added to the Unity codebase.

### Enhancements

* Added configuration option to control whether internal errors are sent to Bugsnag
  [#1701](https://github.com/bugsnag/bugsnag-android/pull/1701)

### Bug fixes

* Fixed Bugsnag interactions with the Google ANR handler on newer versions of Android
  [#1699](https://github.com/bugsnag/bugsnag-android/pull/1699)
* Overwriting & clearing event metadata in the NDK plugin will no longer leave phantom values
  [#1700](https://github.com/bugsnag/bugsnag-android/pull/1700)