### PR TITLE
Bump bugsnag-android dependency to 5.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ## TBD
 
-* Updates the bugsnag-android dependency from v5.22.1 to [v5.23.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5230-2022-06-20)
+* Updates the bugsnag-android dependency from v5.22.1 to [v5.23.1](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5231-2022-06-23)
 * Updates the bugsnag-cocoa dependency from v6.16.8 to [v6.18.1](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6181-2022-06-22)
 
 ## 1.4.0 (2022-05-11)

--- a/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
+++ b/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
@@ -74,7 +74,7 @@
         <insertNewline/>
         <insert>
             com.bugsnag,bugsnag-plugin-android-unreal,1.4.0
-            com.bugsnag,bugsnag-android,5.23.0
+            com.bugsnag,bugsnag-android,5.23.1
         </insert>
         <insertNewline/>
     </AARImports>

--- a/deps/bugsnag-plugin-android-unreal/build.gradle
+++ b/deps/bugsnag-plugin-android-unreal/build.gradle
@@ -28,7 +28,7 @@ android {
 }
 
 dependencies {
-    api "com.bugsnag:bugsnag-android-core:5.23.0"
+    api "com.bugsnag:bugsnag-android-core:5.23.1"
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'junit:junit:4.12'


### PR DESCRIPTION
### Bug fixes

* Report the correct filename for native-libs that are loaded from within apk files
  [#1705](https://github.com/bugsnag/bugsnag-android/pull/1705)