### PR TITLE
[PLAT-8598] Add the `Telemetry` configuration property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ## TBD
 
+* Adds the `Telemetry` configuration property.
 * Updates the bugsnag-android dependency from v5.22.1 to [v5.23.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5230-2022-06-20)
 * Updates the bugsnag-cocoa dependency from v6.16.8 to [v6.19.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6190-2022-06-29)
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/AndroidPlatformConfiguration.cpp
@@ -91,6 +91,11 @@ jobject FAndroidPlatformConfiguration::Parse(JNIEnv* Env,
 	jniCallWithObjects(Env, jConfig, Cache->ConfigSetMaxPersistedSessions, Config->GetMaxPersistedSessions());
 	jniCallWithObjects(Env, jConfig, Cache->ConfigSetMaxReportedThreads, Config->GetMaxReportedThreads());
 	jniCallWithBool(Env, jConfig, Cache->ConfigSetPersistUser, Config->GetPersistUser());
+
+	jobject jTelemetry = FAndroidPlatformJNI::ParseTelemetryTypeSet(Env, Cache, Config->GetTelemetry());
+	ReturnNullOnFail(jTelemetry);
+	jniCallWithObjects(Env, jConfig, Cache->ConfigSetTelemetry, jTelemetry);
+
 	if (Config->GetRedactedKeys().Num())
 	{
 		jniCallWithSet(Env, Cache, jConfig, Cache->ConfigSetRedactedKeys, Config->GetRedactedKeys());

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/JNIUtilities.h
@@ -7,6 +7,7 @@
 #include "BugsnagBreadcrumb.h"
 #include "BugsnagEvent.h"
 #include "BugsnagSettings.h"
+#include "BugsnagTelemetryTypes.h"
 
 typedef struct
 {
@@ -31,6 +32,7 @@ typedef struct
 	jclass MetadataParserClass;
 	jclass MetadataSerializerClass;
 	jclass NotifierClass;
+	jclass TelemetryClass;
 	jclass ThreadClass;
 	jclass ThreadSendPolicyClass;
 	jclass ThreadTypeClass;
@@ -141,6 +143,7 @@ typedef struct
 	jmethodID ConfigSetReleaseStage;
 	jmethodID ConfigSetSendLaunchCrashesSynchronously;
 	jmethodID ConfigSetSendThreads;
+	jmethodID ConfigSetTelemetry;
 	jmethodID ConfigSetUser;
 	jmethodID ConfigSetVersionCode;
 	jmethodID ContextGetApplication;
@@ -283,6 +286,7 @@ typedef struct
 	jfieldID BreadcrumbTypeUser;
 	jfieldID ErrorTypeAndroid;
 	jfieldID ErrorTypeC;
+	jfieldID TelemetryInternalErrors;
 	jfieldID ThreadSendPolicyAlways;
 	jfieldID ThreadSendPolicyUnhandledOnly;
 	jfieldID ThreadSendPolicyNever;
@@ -367,6 +371,8 @@ public:
    * @return A Java object reference or null on failure
    */
 	static jobject ParseBreadcrumbTypeSet(JNIEnv* Env, const JNIReferenceCache* Cache, const EBugsnagEnabledBreadcrumbTypes Value);
+
+	static jobject ParseTelemetryTypeSet(JNIEnv* Env, const JNIReferenceCache* Cache, const EBugsnagTelemetryTypes Value);
 
 	/**
    * Convert a value into a Java Severity

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/Specs/AndroidPlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/Specs/AndroidPlatformConfiguration.spec.cpp
@@ -1,0 +1,65 @@
+// Copyright 2022 Bugsnag. All Rights Reserved.
+
+#include "Android/AndroidJavaEnv.h"
+#include "AutomationTest.h"
+
+#include "../AndroidPlatformConfiguration.h"
+
+//
+// To run the unit tests on Android:
+// * Build & run the example app on a connected Android device.
+// * Open Unreal Editor's "Session Frontend" and find the running game in "My Sessions"
+// * Click the "Automation" tab, select the tests to run, and click "Start Tests"!
+//
+BEGIN_DEFINE_SPEC(FAndroidPlatformConfigurationSpec, "Bugsnag.FAndroidPlatformConfigurationSpec",
+	EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+END_DEFINE_SPEC(FAndroidPlatformConfigurationSpec)
+void FAndroidPlatformConfigurationSpec::Define()
+{
+	static const FString ApiKey = TEXT("0192837465afbecd0192837465afbecd");
+
+	static JNIReferenceCache JNICache;
+	if (!JNICache.loaded)
+	{
+		JNICache.loaded = FAndroidPlatformJNI::LoadReferenceCache(AndroidJavaEnv::GetJavaEnv(), &JNICache);
+	}
+
+	Describe("Telemetry", [this]()
+		{
+			It("Should contain all types by default", [this]()
+				{
+					JNIEnv* Env = AndroidJavaEnv::GetJavaEnv();
+					jmethodID SizeMethod = Env->GetMethodID(Env->FindClass("java/util/Set"), "size", "()I");
+					jmethodID GetTelemetryMethod = Env->GetMethodID(JNICache.ConfigClass, "getTelemetry", "()Ljava/util/Set;");
+					TEST_FALSE(Env->ExceptionCheck());
+
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
+
+					jobject AndroidConfig = FAndroidPlatformConfiguration::Parse(Env, &JNICache, Configuration);
+					jobject AndroidTelemetry = Env->CallObjectMethod(AndroidConfig, GetTelemetryMethod);
+					TEST_TRUE(AndroidTelemetry != nullptr);
+					TEST_FALSE(Env->ExceptionCheck());
+					int Size = Env->CallIntMethod(AndroidTelemetry, SizeMethod);
+					TEST_FALSE(Env->ExceptionCheck());
+					TestEqual(TEXT("Telemetry Set should contain [INTERNAL_ERRORS]"), Size, 1);
+				});
+
+			It("Should be empty after setting EBugsnagTelemetryTypes::None", [this]()
+				{
+					JNIEnv* Env = AndroidJavaEnv::GetJavaEnv();
+					jmethodID SizeMethod = Env->GetMethodID(Env->FindClass("java/util/Set"), "size", "()I");
+					jmethodID GetTelemetryMethod = Env->GetMethodID(JNICache.ConfigClass, "getTelemetry", "()Ljava/util/Set;");
+
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
+					Configuration->SetTelemetry(EBugsnagTelemetryTypes::None);
+
+					jobject AndroidConfig = FAndroidPlatformConfiguration::Parse(Env, &JNICache, Configuration);
+					jobject AndroidTelemetry = Env->CallObjectMethod(AndroidConfig, GetTelemetryMethod);
+					TEST_TRUE(AndroidTelemetry != nullptr);
+					TEST_FALSE(Env->ExceptionCheck());
+					int Size = Env->CallIntMethod(AndroidTelemetry, SizeMethod);
+					TEST_FALSE(Env->ExceptionCheck());
+					TestEqual(TEXT("Telemetry Set should be empty"), Size, 0);
+				});
+		});
+}

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Android/Specs/AutomationTest.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Android/Specs/AutomationTest.h
@@ -1,0 +1,12 @@
+// Copyright 2022 Bugsnag. All Rights Reserved.
+
+#include "Misc/AutomationTest.h"
+
+#define TEST_TRUE(expression) \
+	TestTrue(TEXT(#expression), expression)
+
+#define TEST_FALSE(expression) \
+	TestFalse(TEXT(#expression), expression)
+
+#define TEST_EQUAL(expression, expected) \
+	TestEqual(TEXT(#expression), expression, expected)

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformConfiguration.cpp
@@ -15,6 +15,11 @@
 #import <BugsnagPrivate/BugsnagConfiguration+Private.h>
 #import <BugsnagPrivate/BugsnagNotifier.h>
 
+static BSGTelemetryOptions GetTelemetryTypes(EBugsnagTelemetryTypes Value)
+{
+	return (EnumHasAllFlags(Value, EBugsnagTelemetryTypes::InternalErrors) ? BSGTelemetryInternalErrors : 0);
+}
+
 static BSGThreadSendPolicy GetThreadSendPolicy(EBugsnagSendThreadsPolicy Policy)
 {
 	switch (Policy)
@@ -109,6 +114,8 @@ BugsnagConfiguration* FApplePlatformConfiguration::Configuration(const TSharedRe
 	CocoaConfig.maxPersistedSessions = Configuration->GetMaxPersistedSessions();
 
 	CocoaConfig.persistUser = Configuration->GetPersistUser();
+
+	CocoaConfig.telemetry = GetTelemetryTypes(Configuration->GetTelemetry());
 
 	if (Configuration->GetReleaseStage().IsSet())
 	{

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -46,7 +46,6 @@ void FApplePlatformConfigurationSpec::Define()
 					TEST_TRUE([CocoaConfig.appType isEqual:DefaultConfig.appType]);
 					TEST_TRUE([CocoaConfig.bundleVersion isEqual:DefaultConfig.bundleVersion]);
 					TEST_TRUE([CocoaConfig.redactedKeys isEqual:DefaultConfig.redactedKeys]);
-					TEST_TRUE([CocoaConfig.releaseStage isEqual:DefaultConfig.releaseStage]);
 				});
 
 			It("ApiKey", [this]()
@@ -183,6 +182,16 @@ void FApplePlatformConfigurationSpec::Define()
 					Configuration->SetPersistUser(false);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(CocoaConfig.persistUser, NO);
+				});
+
+			It("Telemetry", [this]()
+				{
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
+					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
+					TEST_TRUE(CocoaConfig.telemetry == BSGTelemetryInternalErrors);
+					Configuration->SetTelemetry(EBugsnagTelemetryTypes::None);
+					CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
+					TEST_TRUE(CocoaConfig.telemetry == 0);
 				});
 
 			It("ReleaseStage", [this]()

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
@@ -33,6 +33,11 @@ static EBugsnagEnabledBreadcrumbTypes Convert(FBugsnagEnabledBreadcrumbTypes Val
 		   (Value.bUser ? EBugsnagEnabledBreadcrumbTypes::User : EBugsnagEnabledBreadcrumbTypes::None);
 }
 
+static EBugsnagTelemetryTypes Convert(const FBugsnagTelemetryTypes& Value)
+{
+	return (Value.bInternalErrors ? EBugsnagTelemetryTypes::InternalErrors : EBugsnagTelemetryTypes::None);
+}
+
 uint64 const FBugsnagConfiguration::AppHangThresholdFatalOnly = INT_MAX;
 
 FBugsnagConfiguration::FBugsnagConfiguration(const FString& ApiKey)
@@ -56,6 +61,7 @@ FBugsnagConfiguration::FBugsnagConfiguration(const UBugsnagSettings& Settings)
 	, MaxPersistedEvents(Settings.MaxPersistedEvents)
 	, MaxPersistedSessions(Settings.MaxPersistedSessions)
 	, bPersistUser(Settings.bPersistUser)
+	, Telemetry(Convert(Settings.Telemetry))
 	, ReleaseStage(UnsetIfEmpty(Settings.ReleaseStage))
 	, AppType(UnsetIfEmpty(Settings.AppType))
 	, AppVersion(UnsetIfEmpty(Settings.AppVersion))

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -9,6 +9,7 @@
 #include "BugsnagMetadataStore.h"
 #include "BugsnagSession.h"
 #include "BugsnagSettings.h"
+#include "BugsnagTelemetryTypes.h"
 #include "BugsnagUser.h"
 
 #include "Dom/JsonObject.h"
@@ -299,6 +300,18 @@ public:
 	void SetPersistUser(bool Value) { bPersistUser = Value; }
 
 	/**
+	 * The types of telemetry that may be sent to Bugsnag for product improvement purposes.
+	 *
+	  * By default all types of telemetry are enabled.
+	 */
+	EBugsnagTelemetryTypes GetTelemetry() const { return Telemetry; }
+
+	/**
+	 * @param Value The types of telemetry that may be sent to Bugsnag for product improvement purposes.
+	 */
+	void SetTelemetry(EBugsnagTelemetryTypes Value) { Telemetry = Value; }
+
+	/**
 	 * The release stage of the application, such as `"production"`, `"development"`, `"beta"` etc.
 	 */
 	const TOptional<FString>& GetReleaseStage() const { return ReleaseStage; }
@@ -573,6 +586,7 @@ private:
 	uint32 MaxPersistedSessions = 128;
 	uint32 MaxReportedThreads = 200;
 	bool bPersistUser = true;
+	EBugsnagTelemetryTypes Telemetry = EBugsnagTelemetryTypes::All;
 	FBugsnagUser User;
 	TOptional<FString> ReleaseStage;
 	TOptional<FString> AppType;

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagSettings.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagSettings.h
@@ -69,6 +69,19 @@ struct FBugsnagErrorTypes
 };
 
 /**
+  * Types of telemetry that may be sent to Bugsnag for product improvement purposes.
+  */
+USTRUCT()
+struct FBugsnagTelemetryTypes
+{
+	GENERATED_BODY()
+
+	// Errors within the Bugsnag SDK.
+	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Advanced Configuration")
+	bool bInternalErrors = true;
+};
+
+/**
  * Controls whether Bugsnag events should include the state of all threads at the time of an error.
  */
 UENUM()
@@ -185,6 +198,10 @@ class BUGSNAG_API UBugsnagSettings : public UObject
 	// Whether User information should be persisted to disk between application runs.
 	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Advanced Configuration")
 	bool bPersistUser = true;
+
+	// The types of telemetry that may be sent to Bugsnag for product improvement purposes.
+	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Advanced Configuration")
+	FBugsnagTelemetryTypes Telemetry;
 
 	///////////////////////////////////////////////////////////////////////////
 	//

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagTelemetryTypes.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagTelemetryTypes.h
@@ -1,0 +1,16 @@
+// Copyright 2022 Bugsnag. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+  * Types of telemetry that may be sent to Bugsnag for product improvement purposes.
+  */
+enum class EBugsnagTelemetryTypes : uint8
+{
+	None = 0,
+	InternalErrors = 1 << 0,
+	All = InternalErrors
+};
+ENUM_CLASS_FLAGS(EBugsnagTelemetryTypes)


### PR DESCRIPTION
## Goal

Allow game developers to control whether Bugsnag sends telemetry data.

## Changeset

Adds `GetTelemetry` and `SetTelemetry` to `FBugsnagConfiguration`.

Adds `EBugsnagTelemetryTypes` enum for use with ☝️ 

Adds `FBugsnagTelemetryTypes` for use in `UBugsnagSettings` - i.e. for the Unreal Editor UI.

Updates Android and iOS config classes to convert telemetry to native representations.

## Testing

Adds unit tests to verify conversion to native representation.