### PR TITLE
[PLAT-8642] Remove Android `discardClasses` workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ## TBD
 
-* Updates the bugsnag-android dependency from v5.22.1 to [v5.23.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5230-2022-06-20)
+* Updates the bugsnag-android dependency from v5.22.1 to [v5.24.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5240-2022-06-30)
 * Updates the bugsnag-cocoa dependency from v6.16.8 to [v6.19.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6190-2022-06-29)
 
 ## 1.4.0 (2022-05-11)

--- a/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
+++ b/Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml
@@ -74,7 +74,7 @@
         <insertNewline/>
         <insert>
             com.bugsnag,bugsnag-plugin-android-unreal,1.4.0
-            com.bugsnag,bugsnag-android,5.23.0
+            com.bugsnag,bugsnag-android,5.24.0
         </insert>
         <insertNewline/>
     </AARImports>

--- a/deps/bugsnag-plugin-android-unreal/build.gradle
+++ b/deps/bugsnag-plugin-android-unreal/build.gradle
@@ -28,7 +28,7 @@ android {
 }
 
 dependencies {
-    api "com.bugsnag:bugsnag-android-core:5.23.0"
+    api "com.bugsnag:bugsnag-android-core:5.24.0"
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'junit:junit:4.12'


### PR DESCRIPTION
## Goal

Remove the `discardClasses` workaround on Android, now that the underlying bug has been fixed:
* https://github.com/bugsnag/bugsnag-android/pull/1710

## Changeset

Removes workaround code from `UnrealPlugin`.

Imports were "optimized" by Android Studio.

## Testing

Verified by existing E2E tests on CI.