### PR TITLE
Fix exception in FJsonObjectFromNSDictionary

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/AppleBugsnagUtils.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/AppleBugsnagUtils.h
@@ -59,6 +59,10 @@ static inline NSNumber* NSNumberFromOptional(const TOptional<T>& Value)
 
 static inline TSharedPtr<FJsonObject> FJsonObjectFromNSDictionary(NSDictionary* Dictionary, NSError** Error = nil)
 {
+	if (!Dictionary || ![NSJSONSerialization isValidJSONObject:Dictionary])
+	{
+		return nullptr;
+	}
 	NSData* Data = [NSJSONSerialization dataWithJSONObject:Dictionary options:0 error:Error];
 	if (Data)
 	{


### PR DESCRIPTION
## Goal

Fix an uncaught exception observed when running unit tests.

## Changeset

Checks `+[NSJSONSerialization isValidJSONObject:]` before calling `+[NSJSONSerialization dataWithJSONObject:options:error:]`, preventing an exception if `Dictionary` is not valid JSON.

## Testing

Verified fix by running unit tests.