### PR TITLE
Use `-[BugsnagMetadata copy]` instead of `-deepCopy`

### DIFF
--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/ApplePlatformBugsnag.cpp
@@ -108,7 +108,7 @@ void FApplePlatformBugsnag::Notify(
 													 device:[Client generateDeviceWithState:SystemInfo]
 											   handledState:HandledState
 													   user:Client.user
-												   metadata:[Client.metadata deepCopy]
+												   metadata:[Client.metadata copy]
 												breadcrumbs:Client.breadcrumbs.breadcrumbs ?: @[]
 													 errors:@[Error]
 													threads:Threads


### PR DESCRIPTION
## Goal

Remove use of `-[BugsnagMetadata deepCopy]` method which is [being removed](https://github.com/bugsnag/bugsnag-cocoa/pull/1444).

## Changeset

Uses `copy` instead of `deepCopy`.

## Testing

Verified no observable changes via existing tests.