### PR TITLE
Ignore invalid sessions from crashing scenarios

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.3'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.23.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 3230db9009a6f5ee9d8beac07deb0d87658521ea
-  tag: v6.9.3
+  revision: a792850d1845604917f0a5332b3fd8a7e481123d
+  tag: v6.23.0
   specs:
-    bugsnag-maze-runner (6.9.3)
+    bugsnag-maze-runner (6.23.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -31,7 +31,7 @@ GEM
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cucumber (7.1.0)
       builder (~> 3.2, >= 3.2.4)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -75,7 +75,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_portile2 (2.8.0)
     multi_test (0.1.2)
-    nokogiri (1.13.3)
+    nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     optimist (3.0.1)

--- a/features/steps/unreal_steps.rb
+++ b/features/steps/unreal_steps.rb
@@ -17,6 +17,7 @@ When('I run {string} and restart the crashed app') do |scenario_name|
 end
 
 When('I run {string} and restart the crashed app for {string}') do |scenario_1, scenario_2|
+  Maze.config.captured_invalid_requests.delete(:sessions)
   run_fixture(:run_scenario, scenario_1, wait_for_crash: true)
   run_fixture(:start_bugsnag, scenario_2)
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,6 +3,9 @@ BeforeAll do
 end
 
 Before do |_scenario|
+  # Reset to defaults in case previous scenario changed them
+  Maze.config.captured_invalid_requests = Set[:errors, :sessions, :builds, :uploads, :sourcemaps]
+
   # Wait long enough for Unreal Engine to finish loading the UI.
   # Appium appears to wait for the activity to be ready, but Unreal
   # does its own loading on a background thread.


### PR DESCRIPTION
## Goal

Fix a flake [observed](https://buildkite.com/bugsnag/bugsnag-unreal/builds/1235#018238eb-75ba-45c4-a7e0-9228dcdbcf35) in overnight run.

## Changeset

Uses `Maze.config.captured_invalid_requests` to ignore invalid session payloads received during crashing scenarios. If the fixture crashes while a session has been partially transmitted, this would otherwise cause the failure linked to above.

## Testing

Verified on CI