### PR TITLE
[PLAT-9257] Bugfix for unsigned arithmetic underflow

### DIFF
--- a/Source/BugsnagExampleEditor.Target.cs
+++ b/Source/BugsnagExampleEditor.Target.cs
@@ -14,5 +14,11 @@ public class BugsnagExampleEditorTarget : TargetRules
 		bUseUnityBuild = false;
 
 		ExtraModuleNames.AddRange( new string[] { "BugsnagExample" } );
+
+		if (Target.Platform == UnrealTargetPlatform.IOS || Target.Platform == UnrealTargetPlatform.Mac)
+		{
+			bOverrideBuildEnvironment = true;
+			AdditionalCompilerArguments = "-Wno-unused-but-set-variable";
+		}
 	}
 }


### PR DESCRIPTION
## Goal

`UBugsnagFunctionLibrary::Notify` would crash if `CaptureStackBackTrace` returned a trace size small enough to cause unsigned underflow when adjusting the stack size to eliminate boilerplate entries.

This PR:

* Casts the actually signed value that `CaptureStackBackTrace` returns back to a signed type.
* Makes sure that an invalid `Depth` can never cause a crash.

## Testing

Manually tested on the example app.
