### PR TITLE
Add Unreal Engine 5.1 to Windows CI machines

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,12 +41,22 @@ steps:
     timeout_in_minutes: 60
     key: plugin_4_27
 
+  # Unreal Engine 4.27 - Windows
   - label: 'Build Plugin - 4.27 Win'
     agents:
       queue: windows-general-wsl
     env:
       UE_VERSION: "4.27"
-      UE_HOME: F:\unreal
+    command: features/scripts/build-plugin-wsl.sh
+    artifact_paths: [Bugsnag-*.zip]
+    timeout_in_minutes: 60
+
+  # Unreal Engine 5.1 - Windows
+  - label: 'Build Plugin - 5.1 Win'
+    agents:
+      queue: windows-general-wsl
+    env:
+      UE_VERSION: "4.27"
     command: features/scripts/build-plugin-wsl.sh
     artifact_paths: [Bugsnag-*.zip]
     timeout_in_minutes: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,7 +56,7 @@ steps:
     agents:
       queue: windows-general-wsl
     env:
-      UE_VERSION: "4.27"
+      UE_VERSION: "5.1"
     command: features/scripts/build-plugin-wsl.sh
     artifact_paths: [Bugsnag-*.zip]
     timeout_in_minutes: 60

--- a/features/scripts/build-plugin-wsl.sh
+++ b/features/scripts/build-plugin-wsl.sh
@@ -8,9 +8,15 @@ UE_HOME="${UE_HOME:-C:\Program Files\Epic Games}"\\UE_$UE_VERSION
 
 UE_RUNUAT="$UE_HOME\Engine\Build\BatchFiles\RunUAT.bat"
 
+if [[ "$UE_VERSION" == "5.1" ]]; then
+  TARGET_PLATFORMS="Win64"
+else
+  TARGET_PLATFORMS="Win32+Win64"
+fi
+
 SCRIPT_DIR=$(pwd)
 
-/mnt/c/windows/system32/cmd.exe /C "$UE_RUNUAT" BuildPlugin -Plugin="$(wslpath -w .)/plugins/Bugsnag/Bugsnag.uplugin" -Package="$(wslpath -w .)/Build/Plugin/Bugsnag" -TargetPlatforms=Win32+Win64
+/mnt/c/windows/system32/cmd.exe /C "$UE_RUNUAT" BuildPlugin -Plugin="$(wslpath -w .)/plugins/Bugsnag/Bugsnag.uplugin" -Package="$(wslpath -w .)/Build/Plugin/Bugsnag" -TargetPlatforms="$TARGET_PLATFORMS"
 
 cd "$SCRIPT_DIR/Build/Plugin"
 


### PR DESCRIPTION
## Goal

Add  Unreal engine 5.1 to  to windows CI machines

## Changeset

Add steps for UE 5.1 to the windows CI machine

## Testing

Covered by CI