### PR TITLE
[PLAT-9258] Compensate for lack of thread safety in Unreal's Android CaptureStackBackTrace

### DIFF
--- a/features/fixtures/generic/Source/TestFixture/ScenarioNames.h
+++ b/features/fixtures/generic/Source/TestFixture/ScenarioNames.h
@@ -15,6 +15,7 @@ static TArray<FString> ScenarioNames = {
 	TEXT("ModifySessionScenario"),
 	TEXT("NotifyChangingEverythingInCallback"),
 	TEXT("NotifyScenario"),
+	TEXT("NotifyMultithreadedScenario"),
 	TEXT("NotifyWithLaunchInfoScenario"),
 	TEXT("OpenBadLevelScenario"),
 	TEXT("OpenLevelBreadcrumbsScenario"),

--- a/features/fixtures/generic/Source/TestFixture/Scenarios/NotifyMultithreadedScenario.cpp
+++ b/features/fixtures/generic/Source/TestFixture/Scenarios/NotifyMultithreadedScenario.cpp
@@ -1,0 +1,69 @@
+#include "Scenario.h"
+
+void notify1LevelDeep()
+{
+	UBugsnagFunctionLibrary::Notify(TEXT("Non-fatal"), TEXT("Calling notify from multiple threads"));
+}
+
+void notify2LevelsDeep()
+{
+	notify1LevelDeep();
+}
+
+void notify3LevelsDeep()
+{
+	notify2LevelsDeep();
+}
+
+void notify4LevelsDeep()
+{
+	notify3LevelsDeep();
+}
+
+class NotifyThread : public FRunnable
+{
+public:
+	uint32 Run() override
+	{
+		for (int i = 0; i < 50; i++)
+		{
+			notify4LevelsDeep();
+			notify1LevelDeep();
+			notify3LevelsDeep();
+			notify2LevelsDeep();
+		}
+		return 0;
+	}
+};
+
+static void createThread()
+{
+	FRunnableThread::Create(new NotifyThread, TEXT("Some Thread"), 0, TPri_BelowNormal);
+}
+
+static void createThreads()
+{
+	for (int i = 0; i < 300; i++)
+	{
+		createThread();
+	}
+}
+
+class NotifyMultithreadedScenario : public Scenario
+{
+public:
+	void Configure() override
+	{
+		Configuration->SetAutoTrackSessions(false);
+	}
+
+	void Run() override
+	{
+		createThreads();
+		FPlatformProcess::Sleep(8);
+		UBugsnagFunctionLibrary::StartSession();
+		FPlatformProcess::Sleep(1);
+	}
+};
+
+REGISTER_SCENARIO(NotifyMultithreadedScenario);

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -133,3 +133,8 @@ Feature: Reporting handled errors
     When I run "StartWithApiKeyScenario"
     And I wait to receive an error
     And the event "context" equals "FromSettings"
+
+  Scenario: Multithreaded notify
+    Given I run "NotifyMultithreadedScenario"
+    And I wait to receive a session
+    Then the session is valid for the session reporting API version "1.0" for the "Unreal Bugsnag Notifier" notifier


### PR DESCRIPTION
## Goal

Unreal's CaptureStackBackTrace implementation for Android has a path that is not thread-safe. Add a mutex to ensure only one thread can call it at a time.

## Testing

Tested manually using multiple threads. Before the fix, it crashes pretty consistently.
