### PR TITLE
Set Android compile SDK version for test fixture

### DIFF
--- a/features/fixtures/generic/Plugins/Tweaks/Source/Tweaks/Tweaks_UPL.xml
+++ b/features/fixtures/generic/Plugins/Tweaks/Source/Tweaks/Tweaks_UPL.xml
@@ -5,6 +5,12 @@
         <addAttribute tag="application" name="android:usesCleartextTraffic" value="true"/>
     </androidManifestUpdates>
 
+    <buildGradleAdditions>
+        <insert>
+            android.compileSdkVersion 31
+        </insert>
+    </buildGradleAdditions>
+    
     <gameActivityImportAdditions>
         <insert>
             import android.content.Intent;


### PR DESCRIPTION
## Goal

Set the compile SDK version for the android test fixture to the supported version. This only affects the test fixture.

## Testing

Covered by full CI