### PR TITLE
Updated breadcrumb clamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 
 * Updates the bugsnag-cocoa dependency from v6.25.2 to [v6.26.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6262-2023-04-20)
 * Updates the bugsnag-android dependency from v5.28.4 to [v5.29.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5290-2023-03-23)
+* Increased MaxBreadcrumb clamp from 100 to 500
 
 ## 1.7.0 (2022-03-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 
 * Updates the bugsnag-cocoa dependency from v6.25.2 to [v6.26.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6262-2023-04-20)
 * Updates the bugsnag-android dependency from v5.28.4 to [v5.29.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5290-2023-03-23)
-* Increased MaxBreadcrumb clamp from 100 to 500
+* Increased MaxBreadcrumb limit from 100 to 500 [#212](https://github.com/bugsnag/bugsnag-unreal/pull/212)
 
 ## 1.7.0 (2022-03-13)
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
@@ -139,9 +139,9 @@ void FBugsnagConfiguration::SetAppHangThresholdMillis(uint64 Value)
 
 void FBugsnagConfiguration::SetMaxBreadcrumbs(uint32 Value)
 {
-	if (Value > 100)
+	if (Value > 500)
 	{
-		UE_LOG(LogBugsnag, Warning, TEXT("Invalid configuration. MaxBreadcrumbs should be a number between 0-100, got %lu"), Value);
+		UE_LOG(LogBugsnag, Warning, TEXT("Invalid configuration. MaxBreadcrumbs should be a number between 0-500, got %lu"), Value);
 	}
 	else
 	{

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagSettings.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagSettings.h
@@ -188,7 +188,7 @@ class BUGSNAG_API UBugsnagSettings : public UObject
 	bool bSendLaunchCrashesSynchronously = true;
 
 	// The maximum number of breadcrumbs to store before deleting the oldest.
-	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Advanced Configuration", Meta = (ClampMax = "100"))
+	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Advanced Configuration", Meta = (ClampMax = "500"))
 	uint32 MaxBreadcrumbs = 50;
 
 	// The maximum number of events to store before deleting the oldest.


### PR DESCRIPTION
## Goal

In the v5.28.0 of the android notifier we upped the max breadcrumbs to 500. The unreal notifier was bumped to use this dependency in v1.5.1. With this android update we should allow for a max of 500 breadcrumbs on events in unreal

## Changeset

maxbreadcrumbs clamp was upped from 100 - 500

## Testing

Set plugin breadcrumbs value to 500 in the editor and then sent 500 breadcrumbs in an event to the dashboard. all breadcrumbs correctly set in dashboard