### PR TITLE
Do not pin Appium version without reason

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -173,7 +173,6 @@ steps:
         run: maze-runner
         command:
           - "--app=/app/build/TestFixture-Android-Shipping-5.0-arm64.apk"
-          - "--appium-version=1.17.0"
           - "--device=ANDROID_11"
           - "--farm=bs"
           - "--order=random"
@@ -201,7 +200,6 @@ steps:
         run: maze-runner
         command:
           - "--app=/app/build/TestFixture-IOS-Shipping-5.0.ipa"
-          - "--appium-version=1.17.0"
           - "--device=IOS_14"
           - "--farm=bs"
           - "--order=random"
@@ -245,7 +243,6 @@ steps:
         run: maze-runner
         command:
           - "--app=/app/build/TestFixture-Android-Shipping-5.1-arm64.apk"
-          - "--appium-version=1.17.0"
           - "--device=ANDROID_11"
           - "--farm=bs"
           - "--order=random"
@@ -273,7 +270,6 @@ steps:
         run: maze-runner
         command:
           - "--app=/app/build/TestFixture-IOS-Shipping-5.1.ipa"
-          - "--appium-version=1.17.0"
           - "--device=IOS_16"
           - "--farm=bs"
           - "--order=random"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -198,7 +198,6 @@ steps:
         run: maze-runner
         command:
           - "--app=/app/build/TestFixture-Android-Shipping-4.27-arm64.apk"
-          - "--appium-version=1.17.0"
           - "--device=ANDROID_11"
           - "--farm=bs"
           - "--order=random"
@@ -226,7 +225,6 @@ steps:
         run: maze-runner
         command:
           - "--app=/app/build/TestFixture-IOS-Shipping-4.27.ipa"
-          - "--appium-version=1.17.0"
           - "--device=IOS_12"
           - "--farm=bs"
           - "--order=random"
@@ -270,7 +268,6 @@ steps:
 #        run: maze-runner
 #        command:
 #          - "--app=/app/build/TestFixture-Android-Shipping-5.2-arm64.apk"
-#          - "--appium-version=1.17.0"
 #          - "--device=ANDROID_13"
 #          - "--farm=bs"
 #          - "--order=random"
@@ -298,7 +295,6 @@ steps:
         run: maze-runner
         command:
           - "--app=/app/build/TestFixture-IOS-Shipping-5.2.ipa"
-          - "--appium-version=1.17.0"
           - "--device=IOS_16"
           - "--farm=bs"
           - "--order=random"

--- a/.buildkite/unreal.5.3.yml
+++ b/.buildkite/unreal.5.3.yml
@@ -89,7 +89,6 @@ steps:
         run: maze-runner
         command:
           - "--app=/app/build/TestFixture-Android-Shipping-5.3-arm64.apk"
-          - "--appium-version=1.17.0"
           - "--device=ANDROID_11"
           - "--farm=bs"
           - "--order=random"
@@ -117,7 +116,6 @@ steps:
         run: maze-runner
         command:
           - "--app=/app/build/TestFixture-IOS-Shipping-5.3.ipa"
-          - "--appium-version=1.17.0"
           - "--device=IOS_16"
           - "--farm=bs"
           - "--order=random"


### PR DESCRIPTION
## Goal

Guard against future removal of Appium 1 from device farms.

## Testing

Covered by a full CI run.