### PR TITLE
Bump the version of Maze Runner to fix CI issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', '~>8.0'
+gem 'bugsnag-maze-runner', '~>8.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       selenium-webdriver (~> 4.2, < 4.6)
     bugsnag (6.26.0)
       concurrent-ruby (~> 1.0)
-    bugsnag-maze-runner (8.7.0)
+    bugsnag-maze-runner (8.13.1)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -70,7 +70,7 @@ GEM
     faye-websocket (0.11.3)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.16.2)
+    ffi (1.16.3)
     hana (1.3.7)
     json_schemer (0.2.25)
       ecma-re-validator (~> 0.3)
@@ -80,19 +80,19 @@ GEM
       uri_template (~> 0.7)
     mime-types (3.5.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0808)
-    mini_portile2 (2.8.4)
+    mime-types-data (3.2023.1003)
+    mini_portile2 (2.8.5)
     multi_test (0.1.2)
-    nokogiri (1.15.4)
+    nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
     power_assert (2.0.3)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.8)
     rake (12.3.3)
-    regexp_parser (2.8.1)
+    regexp_parser (2.8.2)
     rexml (3.2.6)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)
@@ -109,7 +109,7 @@ GEM
     tomlrb (2.0.3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.2)
+    unf_ext (0.0.9.1)
     uri_template (0.7.0)
     webrick (1.7.0)
     websocket (1.2.10)
@@ -121,7 +121,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bugsnag-maze-runner (~> 8.0)
+  bugsnag-maze-runner (> 8.0)
 
 BUNDLED WITH
    2.4.8


### PR DESCRIPTION
## Goal

Bump the version of Maze Runner to 8.13.X to fix the following error.

`Unable to load the EventMachine C extension; To use the pure-ruby reactor, require 'em/pure_ruby'`

## Testing

Covered by CI