### PR TITLE
Change test fixture bundle is to all lower case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ e2e_ios: $(TEST_IOS_APP)
 
 .PHONY: e2e_ios_local
 e2e_ios_local: $(TEST_IOS_APP)
-	ideviceinstaller --uninstall com.bugsnag.examples.UnrealTestFixture
+	ideviceinstaller --uninstall com.bugsnag.fixtures.unreal
 	bundle exec maze-runner --app=$< --farm=local --os=ios --os-version=14 --apple-team-id=7W9PZ27Y5F --udid="$(shell idevice_id -l)" $(TESTS) --color
 
 .PHONY: e2e_mac

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagConfiguration.h
@@ -553,7 +553,7 @@ public:
 	 *
 	 * The callback should return `true` to allow or `false` to prevent the event being sent.
 	 *
-	 * Note that the callback will not normally be invoked on the thread where the error ocurred,
+	 * Note that the callback will not normally be invoked on the thread where the error occurred,
 	 * and may run at a much later point in time or after the application has been relaunched.
 	 */
 	void AddOnSendError(FBugsnagOnErrorCallback Callback) { OnSendErrorCallbacks.Add(Callback); }

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagError.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagError.h
@@ -35,7 +35,7 @@ public:
 	virtual EBugsnagErrorType GetErrorType() const = 0;
 
 	/**
-	 * The stack trace at the time the error ocurred.
+	 * The stack trace at the time the error occurred.
 	 */
 	virtual TArray<TSharedRef<IBugsnagStackframe>> GetStacktrace() const = 0;
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagEvent.h
+++ b/Plugins/Bugsnag/Source/Bugsnag/Public/BugsnagEvent.h
@@ -64,12 +64,12 @@ public:
 	virtual void SetGroupingHash(const TOptional<FString>&) = 0;
 
 	/**
-	 * Information about the app at the time the error ocurred.
+	 * Information about the app at the time the error occurred.
 	 */
 	virtual const TSharedRef<IBugsnagAppWithState> GetApp() const = 0;
 
 	/**
-	 * Information about the computer or device running the app at the time the error ocurred.
+	 * Information about the computer or device running the app at the time the error occurred.
 	 */
 	virtual const TSharedRef<IBugsnagDeviceWithState> GetDevice() const = 0;
 

--- a/features/fixtures/generic/Config/DefaultEngine.ini
+++ b/features/fixtures/generic/Config/DefaultEngine.ini
@@ -10,7 +10,7 @@ GameDefaultMap=/Game/MainLevel.MainLevel
 
 [/Script/AndroidRuntimeSettings.AndroidRuntimeSettings]
 Orientation=Portrait
-PackageName=com.bugsnag.examples.UnrealTestFixture
+PackageName=com.bugsnag.fixtures.unreal
 bBuildForArm64=True
 bPackageDataInsideApk=True
 bShowLaunchImage=False
@@ -35,7 +35,7 @@ ManualIPAddress=
 
 [/Script/IOSRuntimeSettings.IOSRuntimeSettings]
 BundleDisplayName=TestFixture
-BundleIdentifier=com.bugsnag.examples.UnrealTestFixture
+BundleIdentifier=com.bugsnag.fixtures.unreal
 BundleName=TestFixture
 IOSTeamID=7W9PZ27Y5F
 MobileProvision=

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -13,7 +13,7 @@ Feature: Reporting handled errors
     And the event "context" starts with "Lorem ipsum dolor sit amet"
     And the event "app.duration" equals 37
     And the event "app.durationInForeground" is not null
-    And the event "app.id" equals "com.bugsnag.examples.UnrealTestFixture"
+    And the event "app.id" equals "com.bugsnag.fixtures.unreal"
     And the event "app.inForeground" is true
     And the event "app.isLaunching" is true
     And the event "app.releaseStage" equals "production"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -48,7 +48,7 @@ def artifact_path
 end
 
 def app_state
-  Maze.driver.app_state('com.bugsnag.examples.UnrealTestFixture')
+  Maze.driver.app_state('com.bugsnag.fixtures.unreal')
 end
 
 Maze.hooks.before do


### PR DESCRIPTION
## Goal

Fixes failures running the e2e tests caused by the bundle id becoming case-sensitive/changed to lower case on BrowserStack.

## Changeset

Simply chose a new bundle id, all lower case.

## Testing

Covered by CI.