### PR TITLE
Add automatic dependency updates from bugsnag-android and bugsnag-cocoa

### DIFF
--- a/.github/scripts/update-dependencies.rb
+++ b/.github/scripts/update-dependencies.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 
-# require 'bumpsnag'
+require 'bumpsnag'
 
 def update_version(file, from, to)
   initial_content = File.open(file).read

--- a/.github/scripts/update-dependencies.rb
+++ b/.github/scripts/update-dependencies.rb
@@ -1,0 +1,37 @@
+#! /usr/bin/env ruby
+
+# require 'bumpsnag'
+
+def update_version(file, from, to)
+  initial_content = File.open(file).read
+  output_content = initial_content.gsub(from, to)
+  File.open(file, 'w') { |file| file.puts output_content }
+end
+
+target_submodule = ENV['TARGET_SUBMODULE']
+target_version = ENV['TARGET_VERSION']
+
+if target_submodule.nil? || target_version.nil?
+  raise 'Submodule or version targets not provided, exiting'
+  exit(1)
+end
+
+if target_submodule.eql?('bugsnag-android')
+  version = /(\d+\.\d+\.\d+)/.match(target_version)[1]
+  update_version(
+    'Plugins/Bugsnag/Source/Bugsnag/Bugsnag_UPL.xml',
+    /com.bugsnag,bugsnag-android,\d{1,3}\.\d{1,3}\.\d{1,3}/,
+    "com.bugsnag,bugsnag-android,#{version}"
+  )
+  update_version(
+    'deps/bugsnag-plugin-android-unreal/build.gradle',
+    /com.bugsnag:bugsnag-android-core:\d{1,3}\.\d{1,3}\.\d{1,3}/,
+    "com.bugsnag:bugsnag-android-core:#{version}"
+  )
+elsif target_submodule.eql?('bugsnag-cocoa')
+  Bumpsnag.update_submodule('deps/bugsnag-cocoa', target_version)
+else
+  raise "Submodule #{target_submodule} not supported, exiting"
+end
+
+

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,62 @@
+name: update-dependencies
+
+on:
+  repository_dispatch:
+    types: [update-dependency]
+  workflow_dispatch:
+    inputs:
+      target_submodule:
+        description: 'Submodule to update'
+        required: true
+        type: string
+      target_version:
+        description: 'Version of the submodule to update to'
+        required: true
+        type: string
+
+jobs:
+  update-dependencies:
+    runs-on: macos-latest
+    env:
+      SUBMODULE: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_submodule || inputs.target_submodule }}
+      VERSION: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_version || inputs.target_version }}
+      BUNDLE_GITHUB__COM: ${{ secrets.BUNDLE_ACCESS_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REVIEWER: richardelms
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: next
+
+      - run: |
+          git config --global user.name 'Bumpsnag bot'
+          git config --global user.email ''
+
+      - run: git fetch --prune --unshallow
+
+      - name: Install ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Update references locally
+        run: bundle exec .github/scripts/update-dependencies.rb
+
+      - name: Commit and push changes
+        run: bundle exec bumpsnag commit_update $SUBMODULE $VERSION
+
+      - name: List current branch name
+        id: current-branch
+        run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Create pull request
+        if: ${{ steps.current-branch.outputs.branch != 'next'}}
+        run: >
+         gh pr create -B next
+         -H bumpsnag-$SUBMODULE-$VERSION
+         --title "Update $SUBMODULE to version $VERSION"
+         --body 'Created by bumpsnag'
+         --reviewer $REVIEWER

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 gem 'bugsnag-maze-runner', '~>9.0'
 gem 'cocoapods'
+
+# Only install bumpsnag if we're using Github actions
+unless ENV['GITHUB_ACTIONS'].nil?
+  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'main'
+end


### PR DESCRIPTION
## Goal
Adds a workflow to trigger when an upstream dep is released, creating a PR with the repo updated and running tests against it.