### PR TITLE
CI pipeline tidy-up

### DIFF
--- a/.buildkite/block.yml
+++ b/.buildkite/block.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: opensource
+  queue: macos
 
 steps:
   - block: 'Trigger a full build'
@@ -7,4 +7,5 @@ steps:
 
   - label: 'Upload the full test pipeline'
     depends_on: 'trigger-full-build'
+    timeout_in_minutes: 2
     command: buildkite-agent pipeline upload .buildkite/pipeline.full.yml

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,19 +1,23 @@
 agents:
-  queue: opensource
+  queue: macos
 
 steps:
-  - name: 'Append Unreal 5.0 Pipeline'
+  - label: 'Append Unreal 5.0 Pipeline'
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unreal.5.0.yml
 
-  - name: 'Append Unreal 5.1 Pipeline'
+  - label: 'Append Unreal 5.1 Pipeline'
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unreal.5.1.yml
 
-  - name: 'Append Unreal 5.2 Pipeline'
+  - label: 'Append Unreal 5.2 Pipeline'
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unreal.5.2.yml
 
-  - name: 'Append Unreal 5.3 Pipeline'
+  - label: 'Append Unreal 5.3 Pipeline'
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unreal.5.3.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,14 +1,17 @@
 agents:
-  queue: opensource
+  queue: macos
 
 steps:
-  - name: 'Append Unreal 4.27 Pipeline'
+  - label: 'Append Unreal 4.27 Pipeline'
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unreal.4.27.yml
 
-  - name: 'Append Unreal 5.4 Pipeline'
+  - label: 'Append Unreal 5.4 Pipeline'
+    timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unreal.5.4.yml
 
   - label: 'Conditionally trigger full set of tests'
+    timeout_in_minutes: 2
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/.buildkite/unreal.4.27.yml
+++ b/.buildkite/unreal.4.27.yml
@@ -10,7 +10,7 @@ steps:
     steps:
       - label: ":macos: Build Plugin - 4.27"
         key: plugin_4_27
-        timeout_in_minutes: 60
+        timeout_in_minutes: 20
         commands:
           - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
           - make package
@@ -24,7 +24,7 @@ steps:
       - label: ":android: Build E2E - 4.27"
         key: android_fixture_4_27
         depends_on: plugin_4_27
-        timeout_in_minutes: 60
+        timeout_in_minutes: 15
         commands:
           - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
           - features/scripts/build-fixture.sh Android
@@ -39,7 +39,7 @@ steps:
       - label: ":ios: Build E2E - 4.27"
         key: ios_fixture_4_27
         depends_on: plugin_4_27
-        timeout_in_minutes: 60
+        timeout_in_minutes: 15
         commands:
           - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
           - features/scripts/build-fixture.sh IOS
@@ -54,7 +54,7 @@ steps:
       - label: ":mac: Build E2E - 4.27"
         key: mac_fixture_4_27
         depends_on: plugin_4_27
-        timeout_in_minutes: 90
+        timeout_in_minutes: 15
         commands:
           - rm -rf "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
           - features/scripts/build-fixture.sh Mac
@@ -130,7 +130,7 @@ steps:
 
       - label: ":macos: E2E Tests - 4.27 macOS 12"
         depends_on: mac_fixture_4_27
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         plugins:
           artifacts#v1.5.0:
             download:

--- a/.buildkite/unreal.5.0.yml
+++ b/.buildkite/unreal.5.0.yml
@@ -17,7 +17,7 @@ steps:
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
         artifact_paths:
           - Build/Plugin/*.zip
-        timeout_in_minutes: 60
+        timeout_in_minutes: 15
         key: plugin_5_0
 
       - label: 'Build E2E - 5.0 Android'
@@ -35,7 +35,7 @@ steps:
               - build/TestFixture-Android-Shipping-5.0-arm64.apk
               - build/TestFixture-Android-Shipping-5.0-armv7.apk
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 15
         key: android_fixture_5_0
 
       - label: 'Build E2E - 5.0 iOS'
@@ -53,7 +53,7 @@ steps:
               - build/TestFixture-IOS-Shipping-5.0.dSYM
               - build/TestFixture-IOS-Shipping-5.0.ipa
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 15
         key: ios_fixture_5_0
 
       - label: 'Build E2E - 5.0 macOS'
@@ -70,7 +70,7 @@ steps:
             upload:
               - TestFixture-macOS-5.0.zip
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 90
+        timeout_in_minutes: 15
         key: mac_fixture_5_0
 
   - group: ":test_tube: E2E Tests UE 5.0"
@@ -141,7 +141,7 @@ steps:
         env:
           UE_VERSION: "5.0"
           XCODE_VERSION: "13.2.1"
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         commands:
           - echo '--- Extracting test fixture'
           - unzip TestFixture-macOS-5.0.zip

--- a/.buildkite/unreal.5.1.yml
+++ b/.buildkite/unreal.5.1.yml
@@ -17,7 +17,7 @@ steps:
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
         artifact_paths:
           - Build/Plugin/*.zip
-        timeout_in_minutes: 60
+        timeout_in_minutes: 10
         key: plugin_5_1
 
       - label: 'Build E2E - 5.1 Android'
@@ -35,7 +35,7 @@ steps:
               - build/TestFixture-Android-Shipping-5.1-arm64.apk
               - build/TestFixture-Android-Shipping-5.1-armv7.apk
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 10
         key: android_fixture_5_1
 
       - label: 'Build E2E - 5.1 iOS'
@@ -53,7 +53,7 @@ steps:
               - build/TestFixture-IOS-Shipping-5.1.dSYM
               - build/TestFixture-IOS-Shipping-5.1.ipa
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 10
         key: ios_fixture_5_1
 
       - label: 'Build E2E - 5.1 macOS'
@@ -70,7 +70,7 @@ steps:
             upload:
               - TestFixture-macOS-5.1.zip
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 90
+        timeout_in_minutes: 10
         key: mac_fixture_5_1
 
   - group: ":test_tube: E2E Tests UE 5.1"
@@ -141,7 +141,7 @@ steps:
         env:
           UE_VERSION: "5.1"
           XCODE_VERSION: "13.4.1"
-        timeout_in_minutes: 10
+        timeout_in_minutes: 15
         commands:
           - echo '--- Extracting test fixture'
           - unzip TestFixture-macOS-5.1.zip

--- a/.buildkite/unreal.5.2.yml
+++ b/.buildkite/unreal.5.2.yml
@@ -18,7 +18,7 @@ steps:
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
         artifact_paths:
           - Build/Plugin/*.zip
-        timeout_in_minutes: 60
+        timeout_in_minutes: 10
         key: plugin_5_2
 
       - label: 'Build E2E - 5.2 iOS'
@@ -37,7 +37,7 @@ steps:
               - build/TestFixture-IOS-Shipping-5.2.dSYM
               - build/TestFixture-IOS-Shipping-5.2.ipa
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 10
         key: ios_fixture_5_2
 
       - label: 'Build E2E - 5.2 macOS'
@@ -55,7 +55,7 @@ steps:
             upload:
               - TestFixture-macOS-5.2.zip
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 90
+        timeout_in_minutes: 10
         key: mac_fixture_5_2
 
       # Pending PLAT-12734
@@ -117,7 +117,7 @@ steps:
           UE_VERSION: "5.2"
           XCODE_VERSION: "14.1.0"
           JAVA_VERSION: "11"
-        timeout_in_minutes: 10
+        timeout_in_minutes: 20
         commands:
           - echo '--- Extracting test fixture'
           - unzip TestFixture-macOS-5.2.zip

--- a/.buildkite/unreal.5.3.yml
+++ b/.buildkite/unreal.5.3.yml
@@ -17,7 +17,7 @@ steps:
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
         artifact_paths:
           - Build/Plugin/*.zip
-        timeout_in_minutes: 60
+        timeout_in_minutes: 15
         key: plugin_5_3
 
       - label: ":android: Build E2E - 5.3"
@@ -36,7 +36,7 @@ steps:
               - build/TestFixture-Android-Shipping-5.3-arm64.apk
               - build/TestFixture-Android-Shipping-5.3-armv7.apk
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 15
         key: android_fixture_5_3
 
       - label: ":ios: Build E2E - 5.3"
@@ -54,7 +54,7 @@ steps:
               - build/TestFixture-IOS-Shipping-5.3.ipa
               - build/TestFixture-IOS-Shipping-5.3.dSYM
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 15
         key: ios_fixture_5_3
 
       #  Pending PLAT-12735

--- a/.buildkite/unreal.5.4.yml
+++ b/.buildkite/unreal.5.4.yml
@@ -18,7 +18,7 @@ steps:
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
         artifact_paths:
           - Build/Plugin/*.zip
-        timeout_in_minutes: 60
+        timeout_in_minutes: 20
         key: plugin_5_4
 
       - label: ":android: Build E2E - 5.4"
@@ -37,7 +37,7 @@ steps:
               - build/TestFixture-Android-Shipping-5.4-arm64.apk
               - build/TestFixture-Android-Shipping-5.4-armv7.apk
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 20
         key: android_fixture_5_4
 
       - label: ":ios: Build E2E - 5.4"
@@ -56,7 +56,7 @@ steps:
               - build/TestFixture-IOS-Shipping-5.4.ipa
               - build/TestFixture-IOS-Shipping-5.4-file.dSYM
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 20
         key: ios_fixture_5_4
 
       - label: ":mac: Build E2E - 5.4"
@@ -74,7 +74,7 @@ steps:
             upload:
               - TestFixture-macOS-5.4.zip
               - "/Users/administrator/Library/Logs/Unreal Engine/LocalBuildLogs/*"
-        timeout_in_minutes: 90
+        timeout_in_minutes: 20
         key: mac_fixture_5_4
 
   - group: ":test_tube: E2E Tests UE 5.4"


### PR DESCRIPTION
## Goal

General tidy-up of the Buildkite pipeline to:
- Ensure all steps have an adequate but not excessive timeout
- Agent queues are explicitly stated in each file (even if a default is used)
- Generic `macos` queue is used instead of specific macOS versions where possible

## Testing

Covered by a full CI run.