### PR TITLE
Enable Appium session reporting in e2e tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       BROWSER_STACK_USERNAME:
       BROWSER_STACK_ACCESS_KEY:
       MAZE_NO_FAIL_FAST:
+      MAZE_BUGSNAG_API_KEY:
+      MAZE_APPIUM_BUGSNAG_API_KEY:
     volumes:
       - ./build:/app/build
       - ./features/:/app/features/


### PR DESCRIPTION
## Goal

Enable the reporting of Appium sessions to our Bugsnag dashboard.

## Changeset

This is a simple change to allow the environment variable into the Maze Runner Docker container.  Maze Runner then handles the rest.  The variable itself is set in our S3 secrets bucket.

## Testing

I've checked that the relevant entries are appearing in the dashboard.
