### PR TITLE
Allow e2e tests to fallback to using Appium driver.close

### DIFF
--- a/.buildkite/unreal.4.27.yml
+++ b/.buildkite/unreal.4.27.yml
@@ -99,6 +99,7 @@ steps:
               - "--device=ANDROID_11"
               - "--farm=bs"
               - "--order=random"
+              - "--appium-version=1.22.0"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"

--- a/.buildkite/unreal.5.0.yml
+++ b/.buildkite/unreal.5.0.yml
@@ -93,6 +93,7 @@ steps:
               - "--device=ANDROID_11"
               - "--farm=bs"
               - "--order=random"
+              - "--appium-version=1.22.0"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"

--- a/.buildkite/unreal.5.1.yml
+++ b/.buildkite/unreal.5.1.yml
@@ -93,6 +93,7 @@ steps:
               - "--device=ANDROID_11"
               - "--farm=bs"
               - "--order=random"
+              - "--appium-version=1.22.0"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"

--- a/.buildkite/unreal.5.2.yml
+++ b/.buildkite/unreal.5.2.yml
@@ -155,6 +155,7 @@ steps:
       #         - "--device=ANDROID_13"
       #         - "--farm=bs"
       #         - "--order=random"
+      #         - "--appium-version=1.22.0"
       #   concurrency: 5
       #   concurrency_group: browserstack-app
       #   concurrency_method: eager

--- a/.buildkite/unreal.5.3.yml
+++ b/.buildkite/unreal.5.3.yml
@@ -97,6 +97,7 @@ steps:
               - "--device=ANDROID_12"
               - "--farm=bs"
               - "--order=random"
+              - "--appium-version=1.22.0"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"

--- a/.buildkite/unreal.5.4.yml
+++ b/.buildkite/unreal.5.4.yml
@@ -97,6 +97,7 @@ steps:
               - "--device=ANDROID_11"
               - "--farm=bs"
               - "--order=random"
+              - "--appium-version=1.22.0"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"


### PR DESCRIPTION
## Goal

Allow e2e tests to fallback to using Appium driver.close.

## Design

The Android e2e tests will use Appium 1.22 anyway as that's the current default on BrowserStack, but setting it explicitly will mean that Maze Runner will fall back to using driver.close if terminate_app fails (as it frequently does at present).

## Testing

Covered by a full CI run.