### PR TITLE
Fix Unreal Engine 5.6 iOS tests

### DIFF
--- a/.buildkite/unreal.5.6.yml
+++ b/.buildkite/unreal.5.6.yml
@@ -117,38 +117,38 @@ steps:
           automatic:
             - exit_status: -1
               limit: 2
-#     Pending PLAT-15156
-#      - label: ":ios: E2E Tests - 5.6 iOS 16"
-#        depends_on: ios_fixture_5_6
-#        agents:
-#          queue: opensource
-#        timeout_in_minutes: 30
-#        plugins:
-#          artifacts#v1.3.0:
-#            download:
-#              - build/TestFixture-IOS-Shipping-5.6.ipa
-#              - build/TestFixture-IOS-Shipping-5.6-file.dSYM
-#            upload:
-#              - maze_output/failed/**/*
-#          docker-compose#v3.3.0:
-#            run: maze-runner
-#            command:
-#              - "--app=/app/build/TestFixture-IOS-Shipping-5.6.ipa"
-#              - "--device=IOS_18"
-#              - "--farm=bs"
-#              - "--appium-version=1.22.0"
-#              - "--order=random"
-#          test-collector#v1.10.2:
-#            files: "reports/TEST-*.xml"
-#            format: "junit"
-#            branch: "^main|next$$"
-#        concurrency: 5
-#        concurrency_group: browserstack-app
-#        concurrency_method: eager
-#        retry:
-#          automatic:
-#            - exit_status: -1
-#              limit: 2
+
+      - label: ":ios: E2E Tests - 5.6 iOS 16"
+        depends_on: ios_fixture_5_6
+        agents:
+          queue: opensource
+        timeout_in_minutes: 30
+        plugins:
+          artifacts#v1.3.0:
+            download:
+              - build/TestFixture-IOS-Shipping-5.6.ipa
+              - build/TestFixture-IOS-Shipping-5.6-file.dSYM
+            upload:
+              - maze_output/failed/**/*
+          docker-compose#v3.3.0:
+            run: maze-runner
+            command:
+              - "--app=/app/build/TestFixture-IOS-Shipping-5.6.ipa"
+              - "--device=IOS_18"
+              - "--farm=bs"
+              - "--appium-version=1.22.0"
+              - "--order=random"
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+        concurrency: 5
+        concurrency_group: browserstack-app
+        concurrency_method: eager
+        retry:
+          automatic:
+            - exit_status: -1
+              limit: 2
 
 #      Pending PLAT-12729
 #      - label: ":macos: E2E Tests - 5.6 macOS 14"

--- a/features/fixtures/generic/Config/DefaultEngine.ini
+++ b/features/fixtures/generic/Config/DefaultEngine.ini
@@ -49,6 +49,9 @@ bDisableHTTPS=True
 bGeneratedSYMFile=True
 bEnableNSAllowsArbitraryLoads=true
 
+# ATS exception required for UE 5.6 (bs-local.com)
+AdditionalPlistData=<key>NSAppTransportSecurity</key><dict><key>NSExceptionDomains</key><dict><key>bs-local.com</key><dict><key>NSExceptionAllowsInsecureHTTPLoads</key><true/><key>NSIncludesSubdomains</key><true/><key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key><true/><key>NSTemporaryExceptionMinimumTLSVersion</key><string>TLSv1.0</string></dict></dict></dict>
+
 [/Script/Bugsnag.BugsnagSettings]
 bStartAutomaticallyAtLaunch=False
 

--- a/features/fixtures/generic/Config/DefaultEngine.ini
+++ b/features/fixtures/generic/Config/DefaultEngine.ini
@@ -49,7 +49,6 @@ bDisableHTTPS=True
 bGeneratedSYMFile=True
 bEnableNSAllowsArbitraryLoads=true
 
-# ATS exception required for UE 5.6 (bs-local.com)
 AdditionalPlistData=<key>NSAppTransportSecurity</key><dict><key>NSExceptionDomains</key><dict><key>bs-local.com</key><dict><key>NSExceptionAllowsInsecureHTTPLoads</key><true/><key>NSIncludesSubdomains</key><true/><key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key><true/><key>NSTemporaryExceptionMinimumTLSVersion</key><string>TLSv1.0</string></dict></dict></dict>
 
 [/Script/Bugsnag.BugsnagSettings]


### PR DESCRIPTION
## Goal

Due to a change in UE 5.6, we need to explicitly allow the domain used as part of our CI tests within the test fixture. 

I've added `bs-local.com` to the `NSExceptionDomains` within the Info.plist for the iOS app.

## Testing

Covered by CI