### PR TITLE
Fix for incorrect version string on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## TBD
 
-## 2.1.1
-
 ### Changed
 
 * Fix for incorrect version string on macOS [#276](https://github.com/bugsnag/bugsnag-unreal/pull/276)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## TBD
 
-### Dependencies
-
-Update bugsnag-android to [v6.20.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.20.0) [#265](https://github.com/bugsnag/bugsnag-unreal/pull/265)
-
-## 2.1.1 (2026-04-13)
+## 2.1.1
 
 ### Changed
 
 * Fix for incorrect version string on macOS [#276](https://github.com/bugsnag/bugsnag-unreal/pull/276)
+
+### Dependencies
+
+Update bugsnag-android to [v6.20.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.20.0) [#265](https://github.com/bugsnag/bugsnag-unreal/pull/265)
 
 ## 2.1.0 (2025-12-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 Update bugsnag-android to [v6.20.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.20.0) [#265](https://github.com/bugsnag/bugsnag-unreal/pull/265)
 
+## 2.1.1 (2026-04-13)
+
+### Changed
+
+* Fix for incorrect version string on macOS [#276](https://github.com/bugsnag/bugsnag-unreal/pull/276)
+
 ## 2.1.0 (2025-12-01)
 
 ### Changed

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -4,7 +4,6 @@
 
 #include "../ApplePlatformConfiguration.h"
 #include "BugsnagConfiguration.h"
-#include "BugsnagSettings.h"
 
 #include "Misc/ConfigCacheIni.h"
 #include "Misc/ScopeExit.h"

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -244,11 +244,8 @@ void FApplePlatformConfigurationSpec::Define()
 				{
 					GConfig->SetString(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), TEXT("9.9.9"), GGameIni);
 					ON_SCOPE_EXIT { GConfig->RemoveKey(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), GGameIni); };
-
-					UBugsnagSettings* Settings = NewObject<UBugsnagSettings>();
-					Settings->ApiKey = ApiKey;
-					Settings->AppVersion = TEXT("1.2.3");
-					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(*Settings);
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
+					Configuration->SetAppVersion(FString(TEXT("1.2.3")));
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.appVersion.UTF8String), TEXT("1.2.3"));
 				});

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -231,8 +231,24 @@ void FApplePlatformConfigurationSpec::Define()
 #if PLATFORM_MAC
 			It("AppVersionFallsBackToProjectVersion", [this]()
 				{
+					if (!GConfig)
+					{
+						return;
+					}
+					FString PriorProjectVersion;
+					const bool bHadPriorValue = GConfig->GetString(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), PriorProjectVersion, GGameIni);
 					GConfig->SetString(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), TEXT("4.5.6"), GGameIni);
-					ON_SCOPE_EXIT { GConfig->RemoveKey(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), GGameIni); };
+					ON_SCOPE_EXIT
+					{
+						if (bHadPriorValue)
+						{
+							GConfig->SetString(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), *PriorProjectVersion, GGameIni);
+						}
+						else
+						{
+							GConfig->RemoveKey(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), GGameIni);
+						}
+					};
 
 					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
@@ -241,8 +257,25 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("ExplicitAppVersionWinsOverProjectVersion", [this]()
 				{
+					if (!GConfig)
+					{
+						return;
+					}
+					FString PriorProjectVersion;
+					const bool bHadPriorValue = GConfig->GetString(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), PriorProjectVersion, GGameIni);
 					GConfig->SetString(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), TEXT("9.9.9"), GGameIni);
-					ON_SCOPE_EXIT { GConfig->RemoveKey(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), GGameIni); };
+					ON_SCOPE_EXIT
+					{
+						if (bHadPriorValue)
+						{
+							GConfig->SetString(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), *PriorProjectVersion, GGameIni);
+						}
+						else
+						{
+							GConfig->RemoveKey(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), GGameIni);
+						}
+					};
+
 					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
 					Configuration->SetAppVersion(FString(TEXT("1.2.3")));
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -231,6 +231,7 @@ void FApplePlatformConfigurationSpec::Define()
 #if PLATFORM_MAC
 			It("AppVersionFallsBackToProjectVersion", [this]()
 				{
+					TEST_TRUE(GConfig != nullptr);
 					if (!GConfig)
 					{
 						return;
@@ -257,6 +258,7 @@ void FApplePlatformConfigurationSpec::Define()
 
 			It("ExplicitAppVersionWinsOverProjectVersion", [this]()
 				{
+					TEST_TRUE(GConfig != nullptr);
 					if (!GConfig)
 					{
 						return;

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/Apple/Specs/ApplePlatformConfiguration.spec.cpp
@@ -4,7 +4,10 @@
 
 #include "../ApplePlatformConfiguration.h"
 #include "BugsnagConfiguration.h"
+#include "BugsnagSettings.h"
 
+#include "Misc/ConfigCacheIni.h"
+#include "Misc/ScopeExit.h"
 #include "Runtime/Launch/Resources/Version.h"
 
 #import <BugsnagPrivate/BugsnagInternals.h>
@@ -27,6 +30,9 @@ END_DEFINE_SPEC(FApplePlatformConfigurationSpec)
 void FApplePlatformConfigurationSpec::Define()
 {
 	static const FString ApiKey = TEXT("0192837465afbecd0192837465afbecd");
+#if PLATFORM_MAC
+	static const FString GeneralProjectSettingsSection = TEXT("/Script/EngineSettings.GeneralProjectSettings");
+#endif
 
 	Describe("Properties", [this]()
 		{
@@ -222,6 +228,31 @@ void FApplePlatformConfigurationSpec::Define()
 					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
 					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.appVersion.UTF8String), TEXT("1.2.3"));
 				});
+
+#if PLATFORM_MAC
+			It("AppVersionFallsBackToProjectVersion", [this]()
+				{
+					GConfig->SetString(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), TEXT("4.5.6"), GGameIni);
+					ON_SCOPE_EXIT { GConfig->RemoveKey(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), GGameIni); };
+
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(ApiKey);
+					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
+					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.appVersion.UTF8String), TEXT("4.5.6"));
+				});
+
+			It("ExplicitAppVersionWinsOverProjectVersion", [this]()
+				{
+					GConfig->SetString(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), TEXT("9.9.9"), GGameIni);
+					ON_SCOPE_EXIT { GConfig->RemoveKey(*GeneralProjectSettingsSection, TEXT("ProjectVersion"), GGameIni); };
+
+					UBugsnagSettings* Settings = NewObject<UBugsnagSettings>();
+					Settings->ApiKey = ApiKey;
+					Settings->AppVersion = TEXT("1.2.3");
+					TSharedRef<FBugsnagConfiguration> Configuration = MakeShared<FBugsnagConfiguration>(*Settings);
+					BugsnagConfiguration* CocoaConfig = FApplePlatformConfiguration::Configuration(Configuration);
+					TEST_EQUAL(UTF8_TO_TCHAR(CocoaConfig.appVersion.UTF8String), TEXT("1.2.3"));
+				});
+#endif
 
 			It("BundleVersion", [this]()
 				{

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
@@ -287,7 +287,7 @@ void FBugsnagConfiguration::AddDefaults()
 	// If app version isn't explicitly configured in Bugsnag settings, fall back to the
 	// Unreal project's version (Project Settings → Description → Project Version).
 	// macOS only (per project requirements).
-	#if PLATFORM_MAC
+#if PLATFORM_MAC
 	if (!AppVersion.IsSet() && GConfig)
 	{
 		FString ProjectVersion;
@@ -299,7 +299,7 @@ void FBugsnagConfiguration::AddDefaults()
 			}
 		}
 	}
-	#endif
+#endif
 
 	TSharedRef<FJsonObject> DeviceMetadata = MakeShared<FJsonObject>();
 

--- a/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
+++ b/Plugins/Bugsnag/Source/Bugsnag/Private/BugsnagConfiguration.cpp
@@ -8,6 +8,7 @@
 
 #include "Engine/Engine.h"
 #include "GameFramework/GameState.h"
+#include "Misc/ConfigCacheIni.h"
 #include "RHI.h"
 #include "UserActivityTracking.h"
 
@@ -282,6 +283,23 @@ void FBugsnagConfiguration::AddDefaults()
 		ReleaseStage = TEXT("development");
 #endif
 	}
+
+	// If app version isn't explicitly configured in Bugsnag settings, fall back to the
+	// Unreal project's version (Project Settings → Description → Project Version).
+	// macOS only (per project requirements).
+	#if PLATFORM_MAC
+	if (!AppVersion.IsSet() && GConfig)
+	{
+		FString ProjectVersion;
+		if (GConfig->GetString(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), ProjectVersion, GGameIni))
+		{
+			if (!ProjectVersion.IsEmpty())
+			{
+				AppVersion = ProjectVersion;
+			}
+		}
+	}
+	#endif
 
 	TSharedRef<FJsonObject> DeviceMetadata = MakeShared<FJsonObject>();
 

--- a/features/fixtures/generic/Source/TestFixture/ScenarioNames.h
+++ b/features/fixtures/generic/Source/TestFixture/ScenarioNames.h
@@ -20,6 +20,7 @@ static TArray<FString> ScenarioNames = {
 	TEXT("OpenBadLevelScenario"),
 	TEXT("OpenLevelBreadcrumbsScenario"),
 	TEXT("PauseSessionScenario"),
+	TEXT("ProjectVersionFallbackScenario"),
 	TEXT("RedactedKeysScenario"),
 	TEXT("ReleaseStageDisabledScenario"),
 	TEXT("ReleaseStageEnabledScenario"),

--- a/features/fixtures/generic/Source/TestFixture/Scenarios/ProjectVersionFallbackScenario.cpp
+++ b/features/fixtures/generic/Source/TestFixture/Scenarios/ProjectVersionFallbackScenario.cpp
@@ -5,12 +5,20 @@
 class ProjectVersionFallbackScenario : public Scenario
 {
 public:
+	#if PLATFORM_MAC
+	FString PriorProjectVersion;
+	bool bHadPriorProjectVersion = false;
+	bool bOverrodeProjectVersion = false;
+	#endif
+
 	void Configure() override
 	{
 #if PLATFORM_MAC
 		if (GConfig)
 		{
+			bHadPriorProjectVersion = GConfig->GetString(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), PriorProjectVersion, GGameIni);
 			GConfig->SetString(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), TEXT("4.5.6"), GGameIni);
+			bOverrodeProjectVersion = true;
 		}
 
 		delete Configuration;
@@ -24,9 +32,16 @@ public:
 		Scenario::StartBugsnag();
 
 #if PLATFORM_MAC
-		if (GConfig)
+		if (bOverrodeProjectVersion && GConfig)
 		{
-			GConfig->RemoveKey(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), GGameIni);
+			if (bHadPriorProjectVersion)
+			{
+				GConfig->SetString(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), *PriorProjectVersion, GGameIni);
+			}
+			else
+			{
+				GConfig->RemoveKey(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), GGameIni);
+			}
 		}
 #endif
 	}

--- a/features/fixtures/generic/Source/TestFixture/Scenarios/ProjectVersionFallbackScenario.cpp
+++ b/features/fixtures/generic/Source/TestFixture/Scenarios/ProjectVersionFallbackScenario.cpp
@@ -5,11 +5,11 @@
 class ProjectVersionFallbackScenario : public Scenario
 {
 public:
-	#if PLATFORM_MAC
+#if PLATFORM_MAC
 	FString PriorProjectVersion;
 	bool bHadPriorProjectVersion = false;
 	bool bOverrodeProjectVersion = false;
-	#endif
+#endif
 
 	void Configure() override
 	{

--- a/features/fixtures/generic/Source/TestFixture/Scenarios/ProjectVersionFallbackScenario.cpp
+++ b/features/fixtures/generic/Source/TestFixture/Scenarios/ProjectVersionFallbackScenario.cpp
@@ -1,0 +1,40 @@
+#include "Scenario.h"
+
+#include "Misc/ConfigCacheIni.h"
+
+class ProjectVersionFallbackScenario : public Scenario
+{
+public:
+	void Configure() override
+	{
+#if PLATFORM_MAC
+		if (GConfig)
+		{
+			GConfig->SetString(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), TEXT("4.5.6"), GGameIni);
+		}
+
+		delete Configuration;
+		Configuration = new FBugsnagConfiguration(ApiKey);
+		Configuration->SetEndpoints(NotifyEndpoint, SessionsEndpoint);
+#endif
+	}
+
+	void StartBugsnag() override
+	{
+		Scenario::StartBugsnag();
+
+#if PLATFORM_MAC
+		if (GConfig)
+		{
+			GConfig->RemoveKey(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), GGameIni);
+		}
+#endif
+	}
+
+	void Run() override
+	{
+		UBugsnagFunctionLibrary::Notify(TEXT("ProjectVersionFallback"), TEXT("Ensure app.version falls back to ProjectVersion"));
+	}
+};
+
+REGISTER_SCENARIO(ProjectVersionFallbackScenario);

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -78,12 +78,12 @@ Feature: Reporting handled errors
     And the event has a "state" breadcrumb named "Bugsnag loaded"
     And the exception "errorClass" equals "Internal Error happened"
     And the exception "message" equals "Does not compute"
-    And the method of stack frame 0 is equivalent to "NotifyScenario::Run()"
+    And unless iOS, the method of stack frame 0 is equivalent to "NotifyScenario::Run()"
     And the exception "type" equals the platform-dependent string:
       | android | c     |
       | ios     | cocoa |
       | macos   | cocoa |
-    And on iOS, the error payload field "events.0.exceptions.0.stacktrace.0.method" is null
+    # Pending PLAT-16001 And on iOS, the error payload field "events.0.exceptions.0.stacktrace.0.method" is null
     And on iOS, the error payload field "events.0.exceptions.0.stacktrace.0.symbolAddress" is not null
 
   Scenario: Notify after crash

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -21,7 +21,10 @@ Feature: Reporting handled errors
       | android | android |
       | ios     | iOS     |
       | macos   | macOS   |
-    And the event "app.version" equals "1.0"
+    And the event "app.version" equals the platform-dependent string:
+      | android | 1.0     |
+      | ios     | 1.0     |
+      | macos   | 1.0.0.0 |
     And unless iOS, the event "device.freeDisk" is not null
     And the event "device.freeMemory" is not null
     And the event "device.id" equals "51229"
@@ -138,3 +141,12 @@ Feature: Reporting handled errors
     Given I run "NotifyMultithreadedScenario"
     And I wait to receive a session
     Then the session is valid for the session reporting API version "1.0" for the "Unreal Bugsnag Notifier" notifier
+
+  @skip_android
+  @skip_ios
+  Scenario: AppVersion falls back to ProjectVersion on macOS
+    When I run "ProjectVersionFallbackScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Unreal Bugsnag Notifier" notifier
+    And the event "app.version" equals "4.5.6"
+    And the event "unhandled" is false

--- a/features/support/scenario_names.rb
+++ b/features/support/scenario_names.rb
@@ -19,6 +19,7 @@ $scenario_names = [
   'OpenBadLevelScenario',
   'OpenLevelBreadcrumbsScenario',
   'PauseSessionScenario',
+  'ProjectVersionFallbackScenario',
   'RedactedKeysScenario',
   'ReleaseStageDisabledScenario',
   'ReleaseStageEnabledScenario',

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -37,7 +37,7 @@ Feature: Unhandled errors
       | fc1         |                |
       | fc2         | teal           |
       | Bugsnag     |                |
-    And the method of stack frame 0 is equivalent to "BadMemoryAccessScenario::Run()"
+    And unless iOS, the method of stack frame 0 is equivalent to "BadMemoryAccessScenario::Run()"
     And the exception "errorClass" equals the platform-dependent string:
       | android | SIGSEGV        |
       | ios     | EXC_BAD_ACCESS |
@@ -50,7 +50,7 @@ Feature: Unhandled errors
       | android | c     |
       | ios     | cocoa |
       | macos   | cocoa |
-    And on iOS, the error payload field "events.0.exceptions.0.stacktrace.0.method" is null
+    # Pending PLAT-16001 And on iOS, the error payload field "events.0.exceptions.0.stacktrace.0.method" is null
     And on iOS, the error payload field "events.0.exceptions.0.stacktrace.0.symbolAddress" is not null
 
   @skip_android #PLAT-9770


### PR DESCRIPTION
- [x] Review comment requesting test coverage for macOS AppVersion fallback
- [x] Add `#if PLATFORM_MAC` test: ProjectVersion in GConfig → CocoaConfig.appVersion falls back to ProjectVersion
- [x] Add `#if PLATFORM_MAC` test: explicit AppVersion wins over ProjectVersion fallback
- [x] Add required includes (BugsnagSettings.h, Misc/ConfigCacheIni.h, Misc/ScopeExit.h) to spec file
- [x] Extract shared section string constant to `Define()` scope to avoid duplication
- [x] Add null check for `GConfig` before dereferencing in both macOS tests
- [x] Capture prior `ProjectVersion` value and restore it (or remove key if not previously set) via `ON_SCOPE_EXIT` to prevent state leaks across tests